### PR TITLE
fix(engine): make L-stage IDENTITY.md rewrites actually take effect

### DIFF
--- a/engine/regime-to-cc.mjs
+++ b/engine/regime-to-cc.mjs
@@ -118,8 +118,10 @@ export function convertRegime(regimeDir) {
     } catch { /* ignore parse errors in templates */ }
   }
 
-  // Build CC agents from whichever source has data
-  const sourceAgents = oclawAgents.length > 0 ? oclawAgents : tableAgents;
+  // v5.1: IDENTITY.md canonical role mapping is the source of truth.
+  // openclaw.json.template remains only as a legacy fallback for regimes that
+  // haven't been rewritten yet (should be zero after the L-stage PR).
+  const sourceAgents = tableAgents.length > 0 ? tableAgents : oclawAgents;
   const ccAgents = {};
 
   for (const agent of sourceAgents) {


### PR DESCRIPTION
## The bug

v4 engine (regime-to-cc.mjs L122) preferred openclaw.json.template over IDENTITY.md:
```js
const sourceAgents = oclawAgents.length > 0 ? oclawAgents : tableAgents;
```

58 regimes have openclaw.json.template inherited from v4 upstream. Result: the 57-file L-stage canonical rewrite (#6) was cosmetic — every regime still generated v4 default agents.

Most visibly: tang kept silijian (司礼监, Ming-Qing anachronism) despite our #6 fix replacing it with zhongshu-sheren (中书舍人) in IDENTITY.md.

## Fix

One-line flip: IDENTITY.md first, openclaw.json.template as legacy fallback.

## Verification

All 57 regimes now generate historically-authentic agents from their canonical role mapping:

- **tang**: zhongshu-sheren, bingbu, hubu, libu_ritual, gongbu, xingbu, libu_personnel
- **byzantine**: basileus, patriarch, logothete-dromos, logothete-genikon, domestikos, eparch, protoasecretis
- **roman-republic**: consul, senate, tribune, censor, assembly, etc. (per canonical IDENTITY.md)
- **soviet**: politburo, council-of-ministers, etc.

## Test plan

- [x] `npm test` — 9/9 pass
- [x] `npm run validate:regimes` — 0 errors
- [x] `node engine/regime-to-cc.mjs` generates ≥5 agents for all 57 regimes
- [x] tang generates zhongshu-sheren (not silijian)
- [ ] **Deferred**: live `civagent run --v5` on sample regime to confirm agent prompts work end-to-end