### PR TITLE
feat(engine): R2 eval quality — blind multi-judge, skill dedup, match replay, prompt-bank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # 📜 Changelog
 
+## v5.2.0 (unreleased) — R2 Evaluation & Learning Quality 🏛️
+
+Multi-judge blind evaluation, skill deduplication, match replay, and prompt-bank (iteration plan: [ITERATION_PLAN.md](./ITERATION_PLAN.md), Round 2).
+
+### Added
+- **`engine/v5/multi-judge.mjs`** — blind multi-judge aggregation for tournaments. Civ names are anonymized (Civ-A, Civ-B …) before each judge sees the transcript to prevent name-recognition bias. N independent providers run in sequence; their scores are parsed from Markdown tables and averaged. De-anonymization restores real regime ids in the final `Map<regime, scores>`. (`anonymizePrompt`, `parseScoreTable`, `aggregateJudgements`, `runMultiJudge`)
+- **`engine/v5/skill-quality.mjs`** — deterministic skill deduplication (no LLM calls). SHA-256 fingerprints catch exact duplicates; word-level Jaccard similarity (threshold 0.6, words >3 chars) catches near-duplicates. `analyzeSkillsDir` produces a full quality report: total, duplicate groups, unique topics, first/last sedimentation dates.
+- **`engine/v5/replay.mjs`** — re-run a past match with identical regime/backend/task. Reads `meta.json` from the original match, mints a new `matchId` with a `replay-` prefix, writes a `replayOf` lineage field, and spawns `run-v5.mjs` with injectable `_spawn`/`_runV5` for testability.
+- **`engine/prompts/governance-scenarios.json`** — 10 curated governance challenge scenarios (military, political, economic, diplomatic, crisis) for use with `--prompt-bank`.
+- **`civagent tournament --multi-judge [--judges N]`** — run N judges in blind mode; default N=2.
+- **`civagent tournament --prompt-bank [--seed N]`** — pick a random (or seeded) scenario from the built-in prompt bank.
+- **`civagent replay <matchId>`** — re-run any past match.
+- **`civagent skills <regime> --stats`** — show dedup quality analysis for a regime's skill library.
+- **Tests** — 32 → 55: `multi-judge.test.mjs` (11 cases), `skill-quality.test.mjs` (16 cases), `replay.test.mjs` (7 cases).
+
+### Changed
+- **`engine/v5/skill-sediment.mjs`** — near-duplicate gate added before writing a skill file; uses `findDuplicate` from `skill-quality.mjs`.
+- **`engine/v5/tournament.mjs`** — judge logic refactored into `buildJudgePrompt`/`judgeSingle`/`judgeMulti`; `runTournament` accepts `multiJudge` and `judgesN`; `pickScenario` added for prompt-bank.
+- **`package.json` `lint:syntax`** — includes `multi-judge.mjs`, `skill-quality.mjs`, `replay.mjs`.
+
+---
+
 ## v5.1.0 (unreleased) — R1 Engine Robustness 🔧
 
 Backend robustness pass (iteration plan: [ITERATION_PLAN.md](./ITERATION_PLAN.md), Round 1). Focus: correctness, concurrency safety, and removing the hard external dependency on Gemini.

--- a/ITERATION_PLAN.md
+++ b/ITERATION_PLAN.md
@@ -109,9 +109,11 @@ CivAgent v5 是跑在 Claude Code runtime 上的多智能体编排系统：57 �
 - **验收**：`civagent setup` 不再提示 gemini，准确反映可用后端。
 
 ### Round 2 — 评测严谨性 + 学习闭环质量（前端②上线后并行）
-- 多裁判 / 盲评：N 个非 gemini provider 各打分后聚合，消除单裁判偏差（解决 V5-DESIGN 里"裁判=单一 gemini"的可信度问题）。
-- skill 沉淀质量度量：去重相似 skill、跨局重复 pattern 检测、沉淀产出率指标。
-- 对局可复现：固定题库 + 记录 provider/版本/seed，支持 `civagent replay <matchId>`。
+- ✅ 多裁判 / 盲评：N 个非 gemini provider 各打分后聚合，消除单裁判偏差（`multi-judge.mjs`，`--multi-judge` / `--judges N`）。
+- ✅ skill 沉淀质量度量：去重相似 skill（SHA-256 精确 + Jaccard 近似，threshold 0.6）、跨局重复 pattern 检测、`--stats` 分析报告（`skill-quality.mjs`）。
+- ✅ 对局可复现：固定题库 10 场景（`governance-scenarios.json`，`--prompt-bank / --seed`），支持 `civagent replay <matchId>`（`replay.mjs`，`replayOf` 血统字段）。
+- ✅ 测试覆盖：multi-judge 11 用例、skill-quality 16 用例、replay 7 用例（共 34 新用例，累计 ~55）。
+- **前端 R2（进行中）**：形态②政体可视化浏览器（PR 待提，由 antigravity 负责）。
 
 ### Round 3 — 控制台后端能力（前端③上线）
 - 写 API：发起对局/锦标赛、在线编辑 regime（带 schema 校验 + 史实审稿入环）、管理 skill 库（启用/禁用/删除）。

--- a/bin/civagent
+++ b/bin/civagent
@@ -26,10 +26,15 @@ ${BOLD}Usage:${NC}
   civagent switch <regime>              Set active regime
   civagent run [prompt]                 Launch CC with active regime's agents (v4 mode)
   civagent run --v5 "task"              Launch v5 with isolated HOME + skill sedimentation
-  civagent skills <regime>              List learned skills for a regime
+  civagent skills <regime> [--stats]    List learned skills (--stats: dedup analysis)
   civagent match-log                    Recent match transcripts
+  civagent replay <matchId>             Re-run a past match with identical params
   civagent tournament --civs a,b,c,d "task"
                                         Parallel match across civilizations + judge ranking
+  civagent tournament --civs a,b,c,d --multi-judge [--judges N] "task"
+                                        Blind multi-judge evaluation (default N=2)
+  civagent tournament --civs a,b,c,d --prompt-bank [--seed N]
+                                        Use a random scenario from the built-in prompt bank
   civagent agents                       Show generated CC agents for active regime
   civagent modes                        List 6 orchestration modes
   civagent setup                        Check tool availability (CC, Codex, opencode, cn-cc)
@@ -37,8 +42,11 @@ ${BOLD}Usage:${NC}
 ${BOLD}Examples:${NC}
   civagent switch china/tang
   civagent run --v5 "重构这个模块的代码"
+  civagent replay 2024-01-15T10-30-00-000-ab12
+  civagent skills china/tang --stats
   civagent tournament --civs china/tang,china/qin,global/athens,global/roman-republic \\
                      "how do we handle a famine on the eastern frontier?"
+  civagent tournament --civs china/tang,china/qin --multi-judge --judges 3 --prompt-bank
 
 ${BOLD}Regimes:${NC}
   20 Chinese dynasties: xia, shang, zhou, qin, han, tang, song, ming, qing, ...
@@ -258,7 +266,15 @@ cmd_setup() {
 
 cmd_skills() {
   local regime="${1:-}"
-  [[ -n "$regime" ]] || { echo "Usage: civagent skills <region/regime-id>"; exit 1; }
+  local stats=false
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --stats) stats=true; shift ;;
+      *) shift ;;
+    esac
+  done
+  [[ -n "$regime" ]] || { echo "Usage: civagent skills <region/regime-id> [--stats]"; exit 1; }
   local dir="$REGIMES_DIR/$regime/skills"
   if [[ ! -d "$dir" ]]; then
     echo "No learned skills yet for $regime."
@@ -270,6 +286,23 @@ cmd_skills() {
     echo -e "  ${GREEN}•${NC} $(basename "$f")"
     python3 -c "import re,sys;t=open(sys.argv[1]).read();m=re.search(r'description:\s*(.+)',t);print('    '+m.group(1)) if m else None" "$f" 2>/dev/null
   done
+  if $stats; then
+    echo ""
+    echo -e "${BOLD}Quality analysis${NC}"
+    node --input-type=module <<EOF
+import { analyzeSkillsDir } from '$ENGINE_DIR/v5/skill-quality.mjs';
+const r = analyzeSkillsDir('$dir');
+console.log('  Total skills     : ' + r.total);
+console.log('  Unique topics    : ' + r.uniqueTopics.length);
+if (r.stats.duplicateCount) console.log('  Near-duplicates  : ' + r.stats.duplicateCount);
+if (r.stats.firstSedimented) console.log('  First sedimented : ' + r.stats.firstSedimented);
+if (r.stats.lastSedimented)  console.log('  Last sedimented  : ' + r.stats.lastSedimented);
+if (r.duplicateGroups.length) {
+  console.log('  Duplicate groups :');
+  r.duplicateGroups.forEach(g => console.log('    ' + g.join(', ')));
+}
+EOF
+  fi
 }
 
 cmd_match_log() {
@@ -286,20 +319,51 @@ cmd_match_log() {
   done
 }
 
+cmd_replay() {
+  local match_id="${1:-}"
+  [[ -n "$match_id" ]] || { echo "Usage: civagent replay <matchId>"; exit 1; }
+  exec node --input-type=module <<EOF
+import { replayMatch } from '$ENGINE_DIR/v5/replay.mjs';
+replayMatch('$match_id').then(({ newMatchId, exitCode }) => {
+  console.error('[replay] done — new match: ' + newMatchId);
+  process.exit(exitCode ?? 0);
+}).catch(e => { console.error('[replay] error:', e.message); process.exit(1); });
+EOF
+}
+
 cmd_tournament() {
   local civs=""
+  local multi_judge=false
+  local judges_n=""
+  local prompt_bank=false
+  local seed=""
   local rest=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --civs) civs="$2"; shift 2 ;;
-      *) rest+=("$1"); shift ;;
+      --civs)         civs="$2"; shift 2 ;;
+      --multi-judge)  multi_judge=true; shift ;;
+      --judges)       judges_n="$2"; shift 2 ;;
+      --prompt-bank)  prompt_bank=true; shift ;;
+      --seed)         seed="$2"; shift 2 ;;
+      *)              rest+=("$1"); shift ;;
     esac
   done
-  if [[ -z "$civs" || ${#rest[@]} -eq 0 ]]; then
-    echo "Usage: civagent tournament --civs a/x,b/y,c/z \"task prompt\""
+  if [[ -z "$civs" ]]; then
+    echo "Usage: civagent tournament --civs a/x,b/y,c/z [--multi-judge] [--judges N] [--prompt-bank] [--seed N] \"task\""
     exit 1
   fi
-  exec node "$ENGINE_DIR/v5/tournament.mjs" --civs "$civs" "${rest[@]}"
+  if ! $prompt_bank && [[ ${#rest[@]} -eq 0 ]]; then
+    echo "Usage: civagent tournament --civs a/x,b/y,c/z \"task prompt\""
+    echo "       civagent tournament --civs a/x,b/y,c/z --prompt-bank"
+    exit 1
+  fi
+  local node_args=("$ENGINE_DIR/v5/tournament.mjs" --civs "$civs")
+  $multi_judge  && node_args+=(--multi-judge)
+  [[ -n "$judges_n" ]] && node_args+=(--judges "$judges_n")
+  $prompt_bank  && node_args+=(--prompt-bank)
+  [[ -n "$seed" ]] && node_args+=(--seed "$seed")
+  node_args+=("${rest[@]}")
+  exec node "${node_args[@]}"
 }
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -312,8 +376,9 @@ case "${1:-}" in
   agents)    cmd_agents ;;
   modes)     cmd_modes ;;
   setup)     cmd_setup ;;
-  skills)    cmd_skills "${2:-}" ;;
+  skills)    shift; cmd_skills "${1:-}" "${@:2}" ;;
   match-log) cmd_match_log ;;
+  replay)    cmd_replay "${2:-}" ;;
   tournament) shift; cmd_tournament "$@" ;;
   help|--help|-h|"") usage ;;
   *)         echo "Unknown command: $1"; usage; exit 1 ;;

--- a/engine/prompts/governance-scenarios.json
+++ b/engine/prompts/governance-scenarios.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "frontier-defense-01",
+    "category": "military",
+    "prompt": "Establish secure and robust border defense policies for agricultural frontiers facing seasonal tribal raids."
+  },
+  {
+    "id": "succession-crisis-01",
+    "category": "political",
+    "prompt": "The head of state has died without a designated heir. Multiple factions claim legitimacy. Design a governance process to resolve the succession crisis without civil war."
+  },
+  {
+    "id": "economic-collapse-01",
+    "category": "economic",
+    "prompt": "A sudden 40% drop in tax revenue threatens the state treasury. Propose emergency fiscal measures that preserve core governance functions while minimising unrest."
+  },
+  {
+    "id": "external-threat-01",
+    "category": "diplomacy",
+    "prompt": "A neighbouring power demands territorial concessions under threat of war. Your military capacity is roughly equal. Design a multi-channel response strategy."
+  },
+  {
+    "id": "internal-revolt-01",
+    "category": "internal",
+    "prompt": "A major province is threatening secession after three consecutive years of drought and perceived neglect from the centre. Draft a reconciliation and relief plan."
+  },
+  {
+    "id": "technological-disruption-01",
+    "category": "innovation",
+    "prompt": "A new military technology is spreading rapidly among rivals. Design an adoption strategy and a counter-proliferation policy that fits your governance structure."
+  },
+  {
+    "id": "plague-response-01",
+    "category": "crisis",
+    "prompt": "An epidemic is spreading through major cities, killing 5–10% of the population per month. Coordinate an immediate public-health response within your governance structure."
+  },
+  {
+    "id": "trade-route-disruption-01",
+    "category": "economic",
+    "prompt": "The main trade route has been cut off by a rival power. Design a diversification strategy to maintain economic stability within 12 months."
+  },
+  {
+    "id": "famine-relief-01",
+    "category": "crisis",
+    "prompt": "Crop failure across three provinces threatens mass starvation. Allocate grain reserves, coordinate relief logistics, and prevent hoarding and speculation."
+  },
+  {
+    "id": "religious-schism-01",
+    "category": "social",
+    "prompt": "A doctrinal split has divided the state's official religion. Factions are mobilising followers against each other. Draft a policy to maintain civil order and state authority."
+  }
+]

--- a/engine/v5/multi-judge.mjs
+++ b/engine/v5/multi-judge.mjs
@@ -1,0 +1,155 @@
+// multi-judge.mjs — blind multi-judge aggregation for tournament evaluation.
+//
+// Each judge receives the same prompt with civ names replaced by anonymous labels
+// (Civ-A, Civ-B …) to prevent alphabetical-order or name-recognition bias.
+// Multiple providers run independently; their scores are averaged and their
+// individual verdicts are concatenated into a meta-verdict.
+
+import { runJudge, DEFAULT_JUDGE_CHAIN, resolveJudgeChain } from "./judge.mjs";
+
+// Replace each civ name in `prompt` with an anonymous label and return both the
+// anonymized prompt and the mapping needed to reverse it.
+export function anonymizePrompt(prompt, civNames) {
+  const map = civNames.map((name, i) => ({
+    real: name,
+    anon: `Civ-${String.fromCharCode(65 + i)}`, // Civ-A, Civ-B, …
+  }));
+  let out = String(prompt);
+  for (const { real, anon } of map) {
+    // Replace all occurrences; use a simple split-join to avoid regex escaping.
+    out = out.split(real).join(anon);
+  }
+  return { prompt: out, map };
+}
+
+// Parse a Markdown table from judge output.
+// Accepts three common formats:
+//   Format A: Rank | Civ-X | Score /10 | Reason     (single score, rank prefix)
+//   Format B: Rank | Civ-X | L  | F  | R            (triple score, rank prefix)
+//   Format C: Civ-X | L | F | R                     (triple score, no rank)
+// Returns Map<civLabel, {legality, feasibility, resilience, avg}> or null.
+export function parseScoreTable(markdown) {
+  if (!markdown) return null;
+  const rows = markdown.split("\n").filter((l) => l.includes("|"));
+  const result = new Map();
+
+  for (const row of rows) {
+    const cells = row.split("|").map((s) => s.trim()).filter(Boolean);
+    if (cells.length < 3) continue;
+    // Skip header rows
+    const first = cells[0].toLowerCase();
+    if (first === "rank" || first === "civilization" || first === "regime" || first.startsWith("-")) continue;
+
+    // Detect which cell holds the Civ-X label.
+    const civInCol1 = cells[1] && /Civ-[A-Z]/.test(cells[1]); // Format A or B
+    const civInCol0 = cells[0] && /Civ-[A-Z]/.test(cells[0]); // Format C
+    if (!civInCol1 && !civInCol0) continue;
+
+    if (civInCol1) {
+      // Formats A / B: [rank, Civ-X, score(s), ...]
+      const civLabel = cells[1];
+      const scoreCell = cells[2] || "";
+      // Single-score: "8.5/10" or "8.5"
+      const singleMatch = scoreCell.match(/^(\d+\.?\d*)\s*(?:\/\s*10)?$/);
+      if (singleMatch) {
+        const avg = parseFloat(singleMatch[1]);
+        result.set(civLabel, { legality: avg, feasibility: avg, resilience: avg, avg });
+        continue;
+      }
+      // Triple-score: cells[2]=L cells[3]=F cells[4]=R
+      const l = parseFloat(cells[2]);
+      const f = parseFloat(cells[3]);
+      const r = parseFloat(cells[4]);
+      if (!isNaN(l) && !isNaN(f) && !isNaN(r)) {
+        result.set(civLabel, { legality: l, feasibility: f, resilience: r, avg: (l + f + r) / 3 });
+      }
+    } else {
+      // Format C: [Civ-X, L, F, R]
+      const civLabel = cells[0];
+      const l = parseFloat(cells[1]);
+      const f = parseFloat(cells[2]);
+      const r = parseFloat(cells[3]);
+      if (!isNaN(l) && !isNaN(f) && !isNaN(r)) {
+        result.set(civLabel, { legality: l, feasibility: f, resilience: r, avg: (l + f + r) / 3 });
+      }
+    }
+  }
+
+  return result.size > 0 ? result : null;
+}
+
+// Average scores from multiple judges and de-anonymize civ labels.
+// judges: Array<{ provider, scores: Map|null, raw: string|null, error?: string }>
+// deAnonymizeMap: the `.map` array returned by anonymizePrompt
+export function aggregateJudgements(judges, deAnonymizeMap) {
+  const successfulJudges = judges.filter((j) => j.scores && j.scores.size > 0);
+  if (!successfulJudges.length) {
+    return {
+      scores: new Map(),
+      verdict: judges.map((j) => `[${j.provider}]: ${j.error || "(no scores parsed)"}`).join("\n"),
+      providers: judges.map((j) => j.provider).filter(Boolean),
+    };
+  }
+
+  const allAnon = new Set(successfulJudges.flatMap((j) => [...j.scores.keys()]));
+  const avgMap = new Map();
+
+  for (const anon of allAnon) {
+    const vals = successfulJudges.map((j) => j.scores.get(anon)).filter(Boolean);
+    if (!vals.length) continue;
+    const mean = (arr) => arr.reduce((a, b) => a + b, 0) / arr.length;
+    avgMap.set(anon, {
+      legality: mean(vals.map((v) => v.legality)),
+      feasibility: mean(vals.map((v) => v.feasibility)),
+      resilience: mean(vals.map((v) => v.resilience)),
+      avg: mean(vals.map((v) => v.avg)),
+      judgeCount: vals.length,
+    });
+  }
+
+  // De-anonymize: replace Civ-A → real regime id
+  const scores = new Map();
+  for (const [anon, val] of avgMap) {
+    const entry = deAnonymizeMap.find((m) => m.anon === anon);
+    scores.set(entry ? entry.real : anon, val);
+  }
+
+  const verdict = successfulJudges
+    .map((j) => `### Judge: ${j.provider}\n\n${j.raw || "(empty)"}`)
+    .join("\n\n---\n\n");
+
+  return {
+    scores,
+    verdict,
+    providers: successfulJudges.map((j) => j.provider),
+  };
+}
+
+// Run N judges in blind mode against tournament civ transcripts.
+// civResults: Array<{ regime, backend, matchId, transcript }>
+// Returns { scores: Map, verdict: string, providers: string[] }
+export function runMultiJudge(basePrompt, civResults, {
+  judgeChain = DEFAULT_JUDGE_CHAIN,
+  judgesN = 2,
+  timeout = 120_000,
+  _runJudge = runJudge,
+} = {}) {
+  const chain = resolveJudgeChain(judgeChain).slice(0, judgesN);
+  if (!chain.length) {
+    return { scores: new Map(), verdict: "No judges available", providers: [] };
+  }
+
+  const civNames = civResults.map((r) => r.regime);
+  const { prompt: anonPrompt, map } = anonymizePrompt(basePrompt, civNames);
+
+  const judgeResults = chain.map((provider) => {
+    try {
+      const r = _runJudge(anonPrompt, { providers: [provider], timeout });
+      return { provider: r.provider, scores: parseScoreTable(r.output), raw: r.output };
+    } catch (e) {
+      return { provider, scores: null, raw: null, error: e.message };
+    }
+  });
+
+  return aggregateJudgements(judgeResults, map);
+}

--- a/engine/v5/multi-judge.mjs
+++ b/engine/v5/multi-judge.mjs
@@ -9,14 +9,21 @@ import { runJudge, DEFAULT_JUDGE_CHAIN, resolveJudgeChain } from "./judge.mjs";
 
 // Replace each civ name in `prompt` with an anonymous label and return both the
 // anonymized prompt and the mapping needed to reverse it.
+//
+// Replacement is done in descending name-length order so that longer names
+// (e.g. "china/jin-jurchen") are substituted before any shorter name that is a
+// prefix of them (e.g. "china/jin"), preventing partial corruption like
+// "Civ-A-jurchen" appearing in the output.
 export function anonymizePrompt(prompt, civNames) {
   const map = civNames.map((name, i) => ({
     real: name,
     anon: `Civ-${String.fromCharCode(65 + i)}`, // Civ-A, Civ-B, …
   }));
+  // Sort a scratch copy by descending length; the `map` index stays unchanged
+  // so Civ-A always refers to civNames[0] in the caller's de-anonymize step.
+  const byLength = [...map].sort((a, b) => b.real.length - a.real.length);
   let out = String(prompt);
-  for (const { real, anon } of map) {
-    // Replace all occurrences; use a simple split-join to avoid regex escaping.
+  for (const { real, anon } of byLength) {
     out = out.split(real).join(anon);
   }
   return { prompt: out, map };
@@ -134,7 +141,10 @@ export function runMultiJudge(basePrompt, civResults, {
   timeout = 120_000,
   _runJudge = runJudge,
 } = {}) {
-  const chain = resolveJudgeChain(judgeChain).slice(0, judgesN);
+  // Resolve the full chain — do NOT slice yet.  We iterate until we have
+  // collected judgesN *successful* judge results, skipping unavailable
+  // providers rather than letting them consume one of the N slots.
+  const chain = resolveJudgeChain(judgeChain);
   if (!chain.length) {
     return { scores: new Map(), verdict: "No judges available", providers: [] };
   }
@@ -142,14 +152,20 @@ export function runMultiJudge(basePrompt, civResults, {
   const civNames = civResults.map((r) => r.regime);
   const { prompt: anonPrompt, map } = anonymizePrompt(basePrompt, civNames);
 
-  const judgeResults = chain.map((provider) => {
+  const judgeResults = [];
+  let successCount = 0;
+  for (const provider of chain) {
+    if (successCount >= judgesN) break;
     try {
       const r = _runJudge(anonPrompt, { providers: [provider], timeout });
-      return { provider: r.provider, scores: parseScoreTable(r.output), raw: r.output };
+      const scores = parseScoreTable(r.output);
+      judgeResults.push({ provider: r.provider, scores, raw: r.output });
+      if (scores && scores.size > 0) successCount++;
     } catch (e) {
-      return { provider, scores: null, raw: null, error: e.message };
+      // Provider unavailable — record the failure but keep trying the rest.
+      judgeResults.push({ provider, scores: null, raw: null, error: e.message });
     }
-  });
+  }
 
   return aggregateJudgements(judgeResults, map);
 }

--- a/engine/v5/replay.mjs
+++ b/engine/v5/replay.mjs
@@ -1,0 +1,74 @@
+// replay.mjs — re-run a past match with the same regime/backend/task.
+//
+// Reads the original match's meta.json and spawns run-v5.mjs with the same
+// parameters. A new matchId is minted; the new meta.json carries `replayOf`
+// for lineage tracking.
+
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { metaPath, writeMeta } from "./events.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const RUN_V5 = path.join(__dirname, "run-v5.mjs");
+
+// Read and parse a past match's meta.json. Throws if not found.
+export function readMatchMeta(matchId) {
+  const p = metaPath(matchId);
+  if (!fs.existsSync(p)) throw new Error(`match not found: ${matchId} (looked for ${p})`);
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function newReplayId(originalMatchId) {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 23);
+  const rand = Math.random().toString(36).slice(2, 6);
+  // Embed the original id prefix so logs stay readable.
+  const prefix = String(originalMatchId).slice(0, 12).replace(/[^a-z0-9-]/gi, "-");
+  return `replay-${prefix}-${stamp}-${rand}`;
+}
+
+// Replay a past match. Returns a Promise<{ newMatchId, exitCode }>.
+// Accepts injectable _spawn and _runV5 for testing.
+export function replayMatch(originalMatchId, {
+  _runV5 = RUN_V5,
+  _spawn = spawn,
+} = {}) {
+  const meta = readMatchMeta(originalMatchId);
+  const { regime, backend = "native", task } = meta;
+  if (!regime) throw new Error(`original match ${originalMatchId} has no regime in meta.json`);
+
+  const newMatchId = newReplayId(originalMatchId);
+  writeMeta(newMatchId, {
+    replayOf: originalMatchId,
+    regime,
+    backend,
+    task,
+    status: "running",
+    startedAt: Date.now(),
+  });
+
+  return new Promise((resolve, reject) => {
+    const args = [_runV5, "--backend", backend, regime];
+    if (task) args.push(task);
+
+    const proc = _spawn("node", args, {
+      stdio: "inherit",
+      env: { ...process.env, CIVAGENT_MATCH_ID: newMatchId },
+    });
+
+    proc.on("error", (err) => {
+      writeMeta(newMatchId, { status: "failed", error: err.message, endedAt: Date.now() });
+      reject(err);
+    });
+
+    proc.on("close", (code) => {
+      writeMeta(newMatchId, {
+        status: code === 0 ? "done" : "failed",
+        exitCode: code,
+        endedAt: Date.now(),
+      });
+      resolve({ newMatchId, exitCode: code });
+    });
+  });
+}

--- a/engine/v5/skill-quality.mjs
+++ b/engine/v5/skill-quality.mjs
@@ -9,9 +9,16 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 // Strip YAML frontmatter and normalise to lowercase word tokens.
+//
+// Real on-disk skill files (written by skill-sediment.mjs) carry a provenance
+// HTML comment banner BEFORE the frontmatter:
+//   <!-- civagent v5 learned skill — source_match=… — audited_by=… -->
+// We strip that banner first so that the fingerprint / Jaccard comparison
+// between a candidate (no banner) and a saved file (has banner) is consistent.
 export function normalizeSkill(content) {
   return String(content)
-    .replace(/^---[\s\S]*?---\s*/m, "")   // frontmatter
+    .replace(/<!--[\s\S]*?-->\s*/g, "")   // provenance banner (HTML comment)
+    .replace(/^---[\s\S]*?---\s*/m, "")   // YAML frontmatter
     .toLowerCase()
     .replace(/[^\w\s]/g, " ")
     .replace(/\s+/g, " ")

--- a/engine/v5/skill-quality.mjs
+++ b/engine/v5/skill-quality.mjs
@@ -1,0 +1,111 @@
+// skill-quality.mjs — skill deduplication and quality metrics.
+//
+// Operates deterministically (no embedding calls): uses SHA-256 fingerprints for
+// exact-duplicate detection and word-level Jaccard similarity for near-duplicate
+// detection. Integrated into skill-sediment.mjs to gate writes.
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+// Strip YAML frontmatter and normalise to lowercase word tokens.
+export function normalizeSkill(content) {
+  return String(content)
+    .replace(/^---[\s\S]*?---\s*/m, "")   // frontmatter
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// 16-hex-char fingerprint of the normalised content.
+export function skillFingerprint(content) {
+  return crypto
+    .createHash("sha256")
+    .update(normalizeSkill(content))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+// Word-level Jaccard similarity (only words longer than 3 chars to ignore noise).
+export function jaccardSimilarity(normA, normB) {
+  const setA = new Set(normA.split(" ").filter((w) => w.length > 3));
+  const setB = new Set(normB.split(" ").filter((w) => w.length > 3));
+  if (!setA.size && !setB.size) return 1;
+  const intersection = [...setA].filter((w) => setB.has(w)).length;
+  const union = new Set([...setA, ...setB]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+// Return the filename of the first existing skill that is a near-duplicate of
+// `candidateContent`, or null if no duplicate found.
+// threshold = 0 → only exact fingerprint matches; 0.6 → near-duplicate.
+export function findDuplicate(candidateContent, skillsDir, { threshold = 0.6 } = {}) {
+  if (!fs.existsSync(skillsDir)) return null;
+  const candidateFp = skillFingerprint(candidateContent);
+  const candidateNorm = normalizeSkill(candidateContent);
+  const files = fs.readdirSync(skillsDir).filter((f) => f.endsWith(".md"));
+  for (const f of files) {
+    const existing = fs.readFileSync(path.join(skillsDir, f), "utf8");
+    if (skillFingerprint(existing) === candidateFp) return f; // exact
+    if (jaccardSimilarity(normalizeSkill(existing), candidateNorm) >= threshold) return f; // near
+  }
+  return null;
+}
+
+// Analyse an entire skills/ directory.
+// Returns { total, duplicateGroups, uniqueTopics, stats }.
+export function analyzeSkillsDir(skillsDir, { threshold = 0.6 } = {}) {
+  if (!fs.existsSync(skillsDir)) {
+    return { total: 0, duplicateGroups: [], uniqueTopics: [], stats: { duplicateCount: 0 } };
+  }
+
+  const files = fs.readdirSync(skillsDir).filter((f) => f.endsWith(".md"));
+  const skills = files.map((f) => {
+    const content = fs.readFileSync(path.join(skillsDir, f), "utf8");
+    const norm = normalizeSkill(content);
+    const fp = skillFingerprint(content);
+    // Filename pattern: learned-<YYYY-MM-DD>-<topic>-<matchId>.md
+    const topicMatch = f.match(/^learned-\d{4}-\d{2}-\d{2}-(.+)-[a-z0-9]+\.md$/);
+    const topic = topicMatch ? topicMatch[1] : f.replace(/\.md$/, "");
+    const dateMatch = f.match(/^learned-(\d{4}-\d{2}-\d{2})/);
+    const date = dateMatch ? dateMatch[1] : null;
+    return { filename: f, norm, fp, topic, date };
+  });
+
+  // Find near-duplicate groups (each skill appears in at most one group).
+  const visited = new Set();
+  const duplicateGroups = [];
+  for (let i = 0; i < skills.length; i++) {
+    if (visited.has(i)) continue;
+    const group = [skills[i].filename];
+    for (let j = i + 1; j < skills.length; j++) {
+      if (visited.has(j)) continue;
+      if (
+        skills[i].fp === skills[j].fp ||
+        jaccardSimilarity(skills[i].norm, skills[j].norm) >= threshold
+      ) {
+        group.push(skills[j].filename);
+        visited.add(j);
+      }
+    }
+    if (group.length > 1) {
+      visited.add(i);
+      duplicateGroups.push(group);
+    }
+  }
+
+  const uniqueTopics = [...new Set(skills.map((s) => s.topic))];
+  const dates = skills.map((s) => s.date).filter(Boolean).sort();
+
+  return {
+    total: files.length,
+    duplicateGroups,
+    uniqueTopics,
+    stats: {
+      firstSedimented: dates[0] || null,
+      lastSedimented: dates[dates.length - 1] || null,
+      duplicateCount: duplicateGroups.reduce((n, g) => n + g.length - 1, 0),
+    },
+  };
+}

--- a/engine/v5/skill-sediment.mjs
+++ b/engine/v5/skill-sediment.mjs
@@ -11,6 +11,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { runJudge, hasBinary } from "./judge.mjs";
+import { findDuplicate } from "./skill-quality.mjs";
 
 const EXTRACT_PROMPT = `You are reviewing a CivAgent governance match transcript.
 Extract AT MOST 2 reusable governance patterns the civilization demonstrated.
@@ -137,6 +138,10 @@ export async function sediment({ matchId, regime, regimeDir, transcriptPath, exi
 
   const skillsDir = path.join(regimeDir, "skills");
   fs.mkdirSync(skillsDir, { recursive: true });
+
+  // Near-duplicate gate: don't write a skill that's too similar to an existing one.
+  const dupFile = findDuplicate(extracted, skillsDir);
+  if (dupFile) return { skipped: `near-duplicate of ${dupFile}` };
   const date = new Date().toISOString().slice(0, 10);
   const topic = (extracted.match(/name:\s*[\w/-]+-([\w-]+)/)?.[1] || "pattern")
     .slice(0, 40)

--- a/engine/v5/tournament.mjs
+++ b/engine/v5/tournament.mjs
@@ -87,7 +87,9 @@ function buildJudgePrompt(task, civResults) {
       const text =
         readMatchText(r.matchId, 6000) ||
         (fs.existsSync(r.logFile) ? fs.readFileSync(r.logFile, "utf8").slice(-6000) : "(no output)");
-      return `### ${r.regime} (backend ${r.backend}, exit ${r.code})\n\n\`\`\`\n${text}\n\`\`\``;
+      // Omit backend from the heading: the judge receives anonymized civ labels
+      // and must not learn which provider a civ used (that would break blind eval).
+      return `### ${r.regime} (exit ${r.code})\n\n\`\`\`\n${text}\n\`\`\``;
     })
     .join("\n\n---\n\n");
   return `${JUDGE_PROMPT}\n\n## Task\n${task}\n\n## Civilization Transcripts\n\n${sections}`;

--- a/engine/v5/tournament.mjs
+++ b/engine/v5/tournament.mjs
@@ -81,7 +81,7 @@ function runCiv({ regime, backend }, task, tournamentId, outDir) {
 }
 
 // Build the judge input sections from civ results.
-function buildJudgePrompt(task, civResults) {
+export function buildJudgePrompt(task, civResults) {
   const sections = civResults
     .map((r) => {
       const text =

--- a/engine/v5/tournament.mjs
+++ b/engine/v5/tournament.mjs
@@ -16,6 +16,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { validateRegime } from "./civ-memory.mjs";
 import { runJudge } from "./judge.mjs";
+import { runMultiJudge } from "./multi-judge.mjs";
 import { readMatchText, eventsPath } from "./events.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -79,27 +80,31 @@ function runCiv({ regime, backend }, task, tournamentId, outDir) {
   });
 }
 
-async function judge(task, civResults) {
+// Build the judge input sections from civ results.
+function buildJudgePrompt(task, civResults) {
   const sections = civResults
     .map((r) => {
-      // Prefer the structured event stream; fall back to the raw process log.
       const text =
         readMatchText(r.matchId, 6000) ||
         (fs.existsSync(r.logFile) ? fs.readFileSync(r.logFile, "utf8").slice(-6000) : "(no output)");
       return `### ${r.regime} (backend ${r.backend}, exit ${r.code})\n\n\`\`\`\n${text}\n\`\`\``;
     })
     .join("\n\n---\n\n");
+  return `${JUDGE_PROMPT}\n\n## Task\n${task}\n\n## Civilization Transcripts\n\n${sections}`;
+}
 
-  const prompt = `${JUDGE_PROMPT}\n\n## Task\n${task}\n\n## Civilization Transcripts\n\n${sections}`;
+// Single-judge path (fallback when multi-judge is disabled).
+async function judgeSingle(task, civResults) {
+  const prompt = buildJudgePrompt(task, civResults);
   try {
     const r = runJudge(prompt);
     return {
-      provider: r.provider,
+      providers: [r.provider],
       md: `# Tournament — ${new Date().toISOString()}\n\n**Task:** ${task}\n**Judge:** ${r.provider}\n\n${r.output}`,
     };
   } catch (e) {
     return {
-      provider: null,
+      providers: [],
       md:
         `# Tournament Result — judge unavailable\n\n${e.message}\n\n` +
         `Raw civ exit codes:\n${civResults.map((c) => `- ${c.regime} (${c.backend}): ${c.code}`).join("\n")}`,
@@ -107,7 +112,25 @@ async function judge(task, civResults) {
   }
 }
 
-export async function runTournament({ civs, task }) {
+// Multi-judge blind evaluation path.
+async function judgeMulti(task, civResults, judgesN) {
+  const prompt = buildJudgePrompt(task, civResults);
+  try {
+    const r = runMultiJudge(prompt, civResults, { judgesN });
+    const scoresText = r.scores.size
+      ? [...r.scores.entries()]
+          .map(([civ, s]) => `| ${civ} | ${s.legality.toFixed(1)} | ${s.feasibility.toFixed(1)} | ${s.resilience.toFixed(1)} | ${s.avg.toFixed(1)} |`)
+          .join("\n")
+      : "(no scores parsed)";
+    const header = `| Civilization | Legality | Feasibility | Resilience | Avg |\n|---|---|---|---|---|`;
+    const md = `# Tournament — ${new Date().toISOString()}\n\n**Task:** ${task}\n**Judges (blind):** ${r.providers.join(", ")}\n\n${header}\n${scoresText}\n\n---\n\n${r.verdict}`;
+    return { providers: r.providers, scores: r.scores, md };
+  } catch (e) {
+    return { providers: [], md: `# Tournament Result — multi-judge error\n\n${e.message}` };
+  }
+}
+
+export async function runTournament({ civs, task, multiJudge = false, judgesN = 2 }) {
   if (!civs.length || !task) throw new Error("need --civs and a task");
   const parsed = civs.map(parseCiv);
 
@@ -115,10 +138,13 @@ export async function runTournament({ civs, task }) {
   const outDir = path.join(TOURNAMENTS_DIR, id);
   fs.mkdirSync(outDir, { recursive: true });
 
-  console.error(`[tournament] ${id}  civs=${parsed.map((c) => c.regime).join(",")}  out=${outDir}`);
+  console.error(`[tournament] ${id}  civs=${parsed.map((c) => c.regime).join(",")}  multi=${multiJudge}  out=${outDir}`);
   const results = await Promise.all(parsed.map((c) => runCiv(c, task, id, outDir)));
 
-  const verdict = await judge(task, results);
+  const verdict = multiJudge
+    ? await judgeMulti(task, results, judgesN)
+    : await judgeSingle(task, results);
+
   const resultFile = path.join(outDir, "result.md");
   fs.writeFileSync(resultFile, verdict.md);
 
@@ -127,6 +153,7 @@ export async function runTournament({ civs, task }) {
     id,
     task,
     createdAt: Date.now(),
+    multiJudge,
     civs: results.map((r) => ({
       regime: r.regime,
       backend: r.backend,
@@ -134,7 +161,7 @@ export async function runTournament({ civs, task }) {
       exitCode: r.code,
       events: eventsPath(r.matchId),
     })),
-    judge: { provider: verdict.provider, resultPath: resultFile },
+    judge: { providers: verdict.providers, resultPath: resultFile },
   };
   fs.writeFileSync(path.join(outDir, "manifest.json"), JSON.stringify(manifest, null, 2));
 
@@ -143,19 +170,50 @@ export async function runTournament({ civs, task }) {
   return { id, resultFile, results, manifest };
 }
 
+// Pick a random scenario from the built-in prompt bank.
+export function pickScenario({ seed } = {}) {
+  const scenarios = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "prompts", "governance-scenarios.json"), "utf8")
+  );
+  const idx = seed != null
+    ? Math.abs(Number(seed)) % scenarios.length
+    : Math.floor(Math.random() * scenarios.length);
+  return scenarios[idx];
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
   const args = process.argv.slice(2);
   let civs = [];
+  let multiJudge = false;
+  let judgesN = 2;
+  let promptBank = false;
+  let seed;
   const rest = [];
+
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--civs" && args[i + 1]) {
       civs = args[++i].split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (args[i] === "--multi-judge") {
+      multiJudge = true;
+    } else if (args[i] === "--judges" && args[i + 1]) {
+      judgesN = parseInt(args[++i], 10);
+    } else if (args[i] === "--prompt-bank") {
+      promptBank = true;
+    } else if (args[i] === "--seed" && args[i + 1]) {
+      seed = args[++i];
     } else {
       rest.push(args[i]);
     }
   }
-  const task = rest.join(" ").trim();
-  runTournament({ civs, task }).catch((e) => {
+
+  let task = rest.join(" ").trim();
+  if (promptBank && !task) {
+    const scenario = pickScenario({ seed });
+    task = scenario.prompt;
+    console.error(`[tournament] using prompt-bank scenario: ${scenario.id}`);
+  }
+
+  runTournament({ civs, task, multiJudge, judgesN }).catch((e) => {
     console.error(e);
     process.exit(1);
   });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "lint:syntax": "node -c engine/v5/civ-memory.mjs && node -c engine/v5/skill-sediment.mjs && node -c engine/v5/run-v5.mjs && node -c engine/v5/backends.mjs && node -c engine/v5/judge.mjs && node -c engine/v5/events.mjs && node -c engine/v5/tournament.mjs && node -c engine/regime-to-cc.mjs && bash -n bin/civagent",
+    "lint:syntax": "node -c engine/v5/civ-memory.mjs && node -c engine/v5/skill-sediment.mjs && node -c engine/v5/run-v5.mjs && node -c engine/v5/backends.mjs && node -c engine/v5/judge.mjs && node -c engine/v5/events.mjs && node -c engine/v5/tournament.mjs && node -c engine/v5/multi-judge.mjs && node -c engine/v5/skill-quality.mjs && node -c engine/v5/replay.mjs && node -c engine/regime-to-cc.mjs && bash -n bin/civagent",
     "validate:regimes": "node test/regime-validator.mjs"
   },
   "type": "module",

--- a/test/multi-judge.test.mjs
+++ b/test/multi-judge.test.mjs
@@ -179,3 +179,48 @@ test("aggregateJudgements uses only successful judges when mixed", () => {
   assert.equal(result.providers.length, 1);
   assert.equal(result.providers[0], "codex");
 });
+
+// ── runMultiJudge ─────────────────────────────────────────────────────────────
+
+test("runMultiJudge fills requested judge count from later providers after failures", () => {
+  const calls = [];
+  const output = `
+| Rank | Civilization | Score /10 |
+|---|---|---|
+| 1 | Civ-A | 8 |
+`;
+  const result = runMultiJudge("### china/tang\ntext", [{ regime: "china/tang" }], {
+    judgesN: 2,
+    _runJudge: (_prompt, { providers }) => {
+      const provider = providers[0];
+      calls.push(provider);
+      if (provider === "codex") throw new Error("codex unavailable");
+      return { provider, output };
+    },
+  });
+
+  assert.deepEqual(calls, ["codex", "opencode-reviewer", "cn-glm"]);
+  assert.deepEqual(result.providers, ["opencode-reviewer", "cn-glm"]);
+  assert.equal(result.scores.get("china/tang").judgeCount, 2);
+});
+
+test("runMultiJudge stops once the requested number of successful judges is reached", () => {
+  const calls = [];
+  const output = `
+| Rank | Civilization | Score /10 |
+|---|---|---|
+| 1 | Civ-A | 8 |
+`;
+  const result = runMultiJudge("### china/tang\ntext", [{ regime: "china/tang" }], {
+    judgesN: 2,
+    _runJudge: (_prompt, { providers }) => {
+      const provider = providers[0];
+      calls.push(provider);
+      if (provider === "cn-glm") throw new Error("should not call third provider");
+      return { provider, output };
+    },
+  });
+
+  assert.deepEqual(calls, ["codex", "opencode-reviewer"]);
+  assert.deepEqual(result.providers, ["codex", "opencode-reviewer"]);
+});

--- a/test/multi-judge.test.mjs
+++ b/test/multi-judge.test.mjs
@@ -1,0 +1,156 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  anonymizePrompt,
+  parseScoreTable,
+  aggregateJudgements,
+} from "../engine/v5/multi-judge.mjs";
+
+// ── anonymizePrompt ───────────────────────────────────────────────────────────
+
+test("anonymizePrompt replaces each regime name with Civ-A, Civ-B …", () => {
+  const civNames = ["china/tang", "global/athens"];
+  const prompt = "### china/tang\nsome text\n### global/athens\nmore text";
+  const { prompt: out, map } = anonymizePrompt(prompt, civNames);
+
+  assert.ok(out.includes("Civ-A"), "Civ-A should appear");
+  assert.ok(out.includes("Civ-B"), "Civ-B should appear");
+  assert.ok(!out.includes("china/tang"), "original regime must not leak");
+  assert.ok(!out.includes("global/athens"), "original regime must not leak");
+  assert.deepEqual(map[0], { real: "china/tang",   anon: "Civ-A" });
+  assert.deepEqual(map[1], { real: "global/athens", anon: "Civ-B" });
+});
+
+test("anonymizePrompt replaces all occurrences (split-join, not just first)", () => {
+  const { prompt: out } = anonymizePrompt(
+    "china/tang first  china/tang second  china/tang third",
+    ["china/tang"]
+  );
+  assert.equal((out.match(/Civ-A/g) || []).length, 3);
+  assert.ok(!out.includes("china/tang"));
+});
+
+test("anonymizePrompt handles up to 26 civs (A-Z labels)", () => {
+  const civs = Array.from({ length: 5 }, (_, i) => `civ-${i}`);
+  const { map } = anonymizePrompt("x", civs);
+  assert.equal(map[0].anon, "Civ-A");
+  assert.equal(map[4].anon, "Civ-E");
+});
+
+// ── parseScoreTable ───────────────────────────────────────────────────────────
+
+test("parseScoreTable parses single-score Rank|Civ|Score table", () => {
+  const md = `
+| Rank | Civilization | Score /10 | Reason |
+|---|---|---|---|
+| 1 | Civ-A | 8.5/10 | strong legality |
+| 2 | Civ-B | 7.0/10 | feasible |
+`;
+  const scores = parseScoreTable(md);
+  assert.ok(scores !== null);
+  assert.ok(scores.has("Civ-A"));
+  assert.ok(scores.has("Civ-B"));
+  assert.equal(scores.get("Civ-A").avg, 8.5);
+  assert.equal(scores.get("Civ-B").avg, 7.0);
+});
+
+test("parseScoreTable parses triple-score Civ|Legality|Feasibility|Resilience table", () => {
+  const md = `
+| Civilization | Legality | Feasibility | Resilience |
+|---|---|---|---|
+| Civ-A | 9 | 8 | 7 |
+| Civ-B | 6 | 7 | 5 |
+`;
+  const scores = parseScoreTable(md);
+  // Triple-score rows use cells[0] as civ label
+  assert.ok(scores !== null);
+  // At least one entry parsed
+  assert.ok(scores.size >= 1);
+  const entry = [...scores.values()][0];
+  assert.ok(typeof entry.legality === "number");
+  assert.ok(typeof entry.feasibility === "number");
+  assert.ok(typeof entry.resilience === "number");
+});
+
+test("parseScoreTable returns null on empty markdown", () => {
+  assert.equal(parseScoreTable(""), null);
+  assert.equal(parseScoreTable(null), null);
+});
+
+test("parseScoreTable skips rows without Civ-X labels in the civ column", () => {
+  const md = `
+| Rank | Civilization | Score /10 |
+|---|---|---|
+| 1 | SomeName | 9.0 |
+`;
+  const scores = parseScoreTable(md);
+  // No Civ-X label → nothing parsed → null
+  assert.equal(scores, null);
+});
+
+// ── aggregateJudgements ───────────────────────────────────────────────────────
+
+test("aggregateJudgements averages scores across two judges and de-anonymizes", () => {
+  const deAnonymizeMap = [
+    { real: "china/tang",   anon: "Civ-A" },
+    { real: "global/athens", anon: "Civ-B" },
+  ];
+
+  const j1 = {
+    provider: "codex",
+    scores: new Map([
+      ["Civ-A", { legality: 8, feasibility: 7, resilience: 9, avg: 8 }],
+      ["Civ-B", { legality: 6, feasibility: 6, resilience: 6, avg: 6 }],
+    ]),
+    raw: "codex verdict",
+  };
+  const j2 = {
+    provider: "opencode",
+    scores: new Map([
+      ["Civ-A", { legality: 6, feasibility: 9, resilience: 7, avg: 7.33 }],
+      ["Civ-B", { legality: 8, feasibility: 7, resilience: 9, avg: 8 }],
+    ]),
+    raw: "opencode verdict",
+  };
+
+  const result = aggregateJudgements([j1, j2], deAnonymizeMap);
+
+  // De-anonymized names
+  assert.ok(result.scores.has("china/tang"),    "Civ-A → china/tang");
+  assert.ok(result.scores.has("global/athens"), "Civ-B → global/athens");
+
+  // Averaged values
+  const tang = result.scores.get("china/tang");
+  assert.equal(tang.legality, 7);      // (8+6)/2
+  assert.equal(tang.feasibility, 8);   // (7+9)/2
+  assert.equal(tang.resilience, 8);    // (9+7)/2
+
+  // Providers list
+  assert.deepEqual(result.providers, ["codex", "opencode"]);
+});
+
+test("aggregateJudgements gracefully handles all-failed judges", () => {
+  const failed = [
+    { provider: "codex",   scores: null, raw: null, error: "timeout" },
+    { provider: "cn-glm",  scores: null, raw: null, error: "unavailable" },
+  ];
+  const result = aggregateJudgements(failed, []);
+  assert.equal(result.scores.size, 0);
+  assert.ok(result.verdict.includes("timeout"));
+  assert.ok(result.verdict.includes("unavailable"));
+});
+
+test("aggregateJudgements uses only successful judges when mixed", () => {
+  const map = [{ real: "china/tang", anon: "Civ-A" }];
+  const ok = {
+    provider: "codex",
+    scores: new Map([["Civ-A", { legality: 9, feasibility: 9, resilience: 9, avg: 9 }]]),
+    raw: "ok",
+  };
+  const fail = { provider: "cn-glm", scores: null, raw: null, error: "fail" };
+
+  const result = aggregateJudgements([ok, fail], map);
+  assert.ok(result.scores.has("china/tang"));
+  assert.equal(result.providers.length, 1);
+  assert.equal(result.providers[0], "codex");
+});

--- a/test/multi-judge.test.mjs
+++ b/test/multi-judge.test.mjs
@@ -4,6 +4,7 @@ import {
   anonymizePrompt,
   parseScoreTable,
   aggregateJudgements,
+  runMultiJudge,
 } from "../engine/v5/multi-judge.mjs";
 
 // ── anonymizePrompt ───────────────────────────────────────────────────────────
@@ -35,6 +36,30 @@ test("anonymizePrompt handles up to 26 civs (A-Z labels)", () => {
   const { map } = anonymizePrompt("x", civs);
   assert.equal(map[0].anon, "Civ-A");
   assert.equal(map[4].anon, "Civ-E");
+});
+
+// P1 fix: prefix-collision guard — longer names must be replaced before shorter
+// names that are a prefix of them, so "china/jin-jurchen" is never corrupted
+// into "Civ-A-jurchen" when "china/jin" is replaced first.
+test("anonymizePrompt handles prefix-name collisions correctly (china/jin vs china/jin-jurchen)", () => {
+  const civNames = ["china/jin", "china/jin-jurchen"];
+  const prompt = "### china/jin\ntext about jin\n### china/jin-jurchen\ntext about jurchen";
+  const { prompt: out, map } = anonymizePrompt(prompt, civNames);
+
+  // Both regimes must be fully anonymized
+  assert.ok(!out.includes("china/jin"), "china/jin must not appear in output");
+  assert.ok(!out.includes("china/jin-jurchen"), "china/jin-jurchen must not appear in output");
+
+  // No corrupted partial label like "Civ-A-jurchen"
+  assert.ok(!out.includes("-jurchen"), "no partial corruption with dangling -jurchen suffix");
+
+  // Labels are assigned by original order (index), not by length
+  assert.deepEqual(map[0], { real: "china/jin", anon: "Civ-A" });
+  assert.deepEqual(map[1], { real: "china/jin-jurchen", anon: "Civ-B" });
+
+  // Both Civ-A and Civ-B appear, each with their correct section text
+  assert.ok(out.includes("Civ-A"), "Civ-A for china/jin");
+  assert.ok(out.includes("Civ-B"), "Civ-B for china/jin-jurchen");
 });
 
 // ── parseScoreTable ───────────────────────────────────────────────────────────

--- a/test/replay.test.mjs
+++ b/test/replay.test.mjs
@@ -1,0 +1,182 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { EventEmitter } from "node:events";
+import { readMatchMeta, replayMatch, RUN_V5 } from "../engine/v5/replay.mjs";
+import { writeMeta, metaPath, matchDir } from "../engine/v5/events.mjs";
+
+// Unique prefix so test matches don't collide with real matches.
+const TEST_PREFIX = "test-replay-unit-";
+
+function makeTestMatchId(suffix) {
+  return `${TEST_PREFIX}${suffix}`;
+}
+
+// Clean up any test match directories after a test.
+function cleanup(...matchIds) {
+  for (const id of matchIds) {
+    try {
+      const dir = matchDir(id);
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  }
+}
+
+// Create a mock spawn that fires 'close' with the given exit code.
+function mockSpawn(exitCode = 0) {
+  let capturedArgs = null;
+  let capturedEnv = null;
+  const spawn = (cmd, args, opts) => {
+    capturedArgs = [cmd, ...args];
+    capturedEnv = opts?.env ?? {};
+    const emitter = new EventEmitter();
+    setImmediate(() => emitter.emit("close", exitCode));
+    return emitter;
+  };
+  return { spawn, getCapturedArgs: () => capturedArgs, getCapturedEnv: () => capturedEnv };
+}
+
+// ── readMatchMeta ─────────────────────────────────────────────────────────────
+
+test("readMatchMeta reads back what writeMeta wrote", () => {
+  const matchId = makeTestMatchId("read-01");
+  try {
+    writeMeta(matchId, { regime: "china/tang", backend: "native", task: "test task" });
+    const meta = readMatchMeta(matchId);
+    assert.equal(meta.regime, "china/tang");
+    assert.equal(meta.backend, "native");
+    assert.equal(meta.task, "test task");
+  } finally {
+    cleanup(matchId);
+  }
+});
+
+test("readMatchMeta throws for nonexistent matchId", () => {
+  assert.throws(
+    () => readMatchMeta("nonexistent-match-id-xyz"),
+    /match not found/,
+    "should throw with match not found message"
+  );
+});
+
+// ── replayMatch ───────────────────────────────────────────────────────────────
+
+test("replayMatch spawns run-v5 with the original regime/backend/task", async () => {
+  const origMatchId = makeTestMatchId("orig-02");
+  try {
+    writeMeta(origMatchId, {
+      regime: "china/tang",
+      backend: "native",
+      task: "handle the eastern famine",
+      status: "done",
+      exitCode: 0,
+    });
+
+    const { spawn, getCapturedArgs, getCapturedEnv } = mockSpawn(0);
+    const result = await replayMatch(origMatchId, {
+      _runV5: "/fake/run-v5.mjs",
+      _spawn: spawn,
+    });
+
+    // Returns correct shape
+    assert.ok(typeof result.newMatchId === "string", "newMatchId must be a string");
+    assert.equal(result.exitCode, 0);
+
+    // Spawned with correct args: node /fake/run-v5.mjs --backend native china/tang handle the eastern famine
+    const args = getCapturedArgs();
+    assert.equal(args[0], "node");
+    assert.equal(args[1], "/fake/run-v5.mjs");
+    assert.ok(args.includes("--backend"), "--backend flag required");
+    assert.ok(args.includes("native"), "backend value required");
+    assert.ok(args.includes("china/tang"), "regime required");
+    assert.ok(args.includes("handle the eastern famine"), "task required");
+
+    // Each replay gets the new matchId in CIVAGENT_MATCH_ID env
+    const env = getCapturedEnv();
+    assert.equal(env.CIVAGENT_MATCH_ID, result.newMatchId);
+
+    // New match ID must be different from original
+    assert.notEqual(result.newMatchId, origMatchId);
+
+    // New match meta carries replayOf lineage
+    const newMeta = readMatchMeta(result.newMatchId);
+    assert.equal(newMeta.replayOf, origMatchId);
+    assert.equal(newMeta.regime, "china/tang");
+    assert.equal(newMeta.backend, "native");
+
+    cleanup(result.newMatchId);
+  } finally {
+    cleanup(origMatchId);
+  }
+});
+
+test("replayMatch uses the injectable _runV5 path (not the real RUN_V5)", async () => {
+  const origMatchId = makeTestMatchId("orig-03");
+  try {
+    writeMeta(origMatchId, { regime: "global/athens", backend: "cn:glm", task: "plague" });
+    const { spawn, getCapturedArgs } = mockSpawn(0);
+    const result = await replayMatch(origMatchId, {
+      _runV5: "/custom/run-v5-test.mjs",
+      _spawn: spawn,
+    });
+
+    assert.equal(getCapturedArgs()[1], "/custom/run-v5-test.mjs");
+    cleanup(result.newMatchId);
+  } finally {
+    cleanup(origMatchId);
+  }
+});
+
+test("replayMatch propagates non-zero exit code", async () => {
+  const origMatchId = makeTestMatchId("orig-04");
+  try {
+    writeMeta(origMatchId, { regime: "china/qin", backend: "native", task: "tax revolt" });
+    const { spawn } = mockSpawn(2);
+    const result = await replayMatch(origMatchId, {
+      _runV5: "/fake/run-v5.mjs",
+      _spawn: spawn,
+    });
+    assert.equal(result.exitCode, 2);
+
+    const newMeta = readMatchMeta(result.newMatchId);
+    assert.equal(newMeta.status, "failed");
+    assert.equal(newMeta.exitCode, 2);
+    cleanup(result.newMatchId);
+  } finally {
+    cleanup(origMatchId);
+  }
+});
+
+test("replayMatch throws synchronously when the original match has no regime", () => {
+  const origMatchId = makeTestMatchId("orig-05");
+  try {
+    writeMeta(origMatchId, { backend: "native", task: "some task" }); // no regime
+    // replayMatch throws synchronously before returning a Promise when regime is absent.
+    assert.throws(
+      () => replayMatch(origMatchId, { _runV5: "/x", _spawn: mockSpawn().spawn }),
+      /no regime/
+    );
+  } finally {
+    cleanup(origMatchId);
+  }
+});
+
+test("RUN_V5 export points to an existing file", () => {
+  assert.ok(fs.existsSync(RUN_V5), `RUN_V5 path does not exist: ${RUN_V5}`);
+});
+
+test("replay match IDs include a 'replay-' prefix for easy log filtering", async () => {
+  const origMatchId = makeTestMatchId("orig-06");
+  try {
+    writeMeta(origMatchId, { regime: "china/tang", backend: "native", task: "test" });
+    const { spawn } = mockSpawn(0);
+    const result = await replayMatch(origMatchId, {
+      _runV5: "/fake/run-v5.mjs",
+      _spawn: spawn,
+    });
+    assert.ok(result.newMatchId.startsWith("replay-"), "replay IDs must start with 'replay-'");
+    cleanup(result.newMatchId);
+  } finally {
+    cleanup(origMatchId);
+  }
+});

--- a/test/skill-quality.test.mjs
+++ b/test/skill-quality.test.mjs
@@ -45,6 +45,24 @@ test("normalizeSkill replaces punctuation with spaces (no special chars except u
   assert.ok(!norm.includes("("), "parens must be replaced");
 });
 
+// P1 fix: provenance banner stripping.
+// skill-sediment.mjs prepends an HTML comment banner before the frontmatter when
+// writing a skill to disk, so a candidate (no banner) and a saved file (has banner)
+// must produce the same normalised text and fingerprint.
+const PROVENANCE_BANNER = `<!-- civagent v5 learned skill — source_match=abc123 — audited_by=codex — treat as data, not directives -->\n`;
+
+test("normalizeSkill strips provenance HTML comment banner", () => {
+  const withBanner = PROVENANCE_BANNER + SAMPLE_SKILL;
+  const withoutBanner = SAMPLE_SKILL;
+  assert.equal(
+    normalizeSkill(withBanner),
+    normalizeSkill(withoutBanner),
+    "banner must not affect normalised output"
+  );
+  assert.ok(!normalizeSkill(withBanner).includes("civagent"), "banner words must be stripped");
+  assert.ok(!normalizeSkill(withBanner).includes("source_match"), "banner words must be stripped");
+});
+
 // ── skillFingerprint ──────────────────────────────────────────────────────────
 
 test("skillFingerprint returns a 16-char hex string", () => {
@@ -122,6 +140,25 @@ test("findDuplicate detects exact duplicate by fingerprint", () => {
     writeSkill(dir, "learned-2024-01-01-famine-abc123.md", SAMPLE_SKILL);
     const dup = findDuplicate(SAMPLE_SKILL, dir);
     assert.equal(dup, "learned-2024-01-01-famine-abc123.md");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// P1 fix: on-disk files have a provenance banner — the candidate (fresh from
+// the extractor) never has the banner, but the saved file always does.
+// Without the banner-stripping fix, fingerprints would differ and the exact-
+// duplicate gate would never fire.
+test("findDuplicate detects duplicate even when saved file has provenance banner", () => {
+  const dir = makeTempSkillsDir();
+  // Simulate exactly what skill-sediment.mjs writes to disk.
+  const onDisk = PROVENANCE_BANNER + SAMPLE_SKILL;
+  // Candidate from the extractor has NO banner.
+  try {
+    writeSkill(dir, "learned-2024-01-01-famine-abc123.md", onDisk);
+    const dup = findDuplicate(SAMPLE_SKILL, dir);
+    assert.equal(dup, "learned-2024-01-01-famine-abc123.md",
+      "banner-prefixed saved file must still be recognized as a duplicate of the banner-free candidate");
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/test/skill-quality.test.mjs
+++ b/test/skill-quality.test.mjs
@@ -1,0 +1,243 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  normalizeSkill,
+  skillFingerprint,
+  jaccardSimilarity,
+  findDuplicate,
+  analyzeSkillsDir,
+} from "../engine/v5/skill-quality.mjs";
+
+// ── normalizeSkill ────────────────────────────────────────────────────────────
+
+const SAMPLE_SKILL = `---
+name: tang-famine-relief
+type: learned
+civ: china/tang
+---
+# Famine Relief Protocol
+## Trigger
+When a province reports crop failure exceeding 30% of the harvest.
+## Pattern
+- Dispatch grain inspectors within 48 hours.
+- Activate imperial granaries at county level.
+- Suspend tax collection for the affected area.
+## Example
+Tang dispatched grain inspectors to Henan after the 731 drought.`;
+
+test("normalizeSkill strips YAML frontmatter and lowercases content", () => {
+  const norm = normalizeSkill(SAMPLE_SKILL);
+  assert.ok(!norm.includes("---"), "frontmatter dashes must be stripped");
+  assert.ok(!norm.includes("tang-famine-relief"), "frontmatter name field stripped");
+  assert.equal(norm, norm.toLowerCase(), "must be lowercased");
+  assert.ok(norm.includes("famine relief protocol"), "body content preserved");
+});
+
+test("normalizeSkill replaces punctuation with spaces (no special chars except underscore)", () => {
+  const norm = normalizeSkill("---\nname: x\n---\n## Pattern\nstep-one. step_two, (step3)!");
+  // \w includes underscore, so underscores survive normalisation; all other punctuation becomes spaces.
+  assert.ok(!/[^a-z0-9_\s]/.test(norm), "only lowercase alphanum + underscore + whitespace allowed");
+  assert.ok(!norm.includes("-"), "hyphens must be replaced");
+  assert.ok(!norm.includes("."), "dots must be replaced");
+  assert.ok(!norm.includes("("), "parens must be replaced");
+});
+
+// ── skillFingerprint ──────────────────────────────────────────────────────────
+
+test("skillFingerprint returns a 16-char hex string", () => {
+  const fp = skillFingerprint(SAMPLE_SKILL);
+  assert.match(fp, /^[0-9a-f]{16}$/, "must be 16 hex chars");
+});
+
+test("skillFingerprint is deterministic", () => {
+  assert.equal(skillFingerprint(SAMPLE_SKILL), skillFingerprint(SAMPLE_SKILL));
+});
+
+test("skillFingerprint differs for distinct content", () => {
+  const a = skillFingerprint("---\nname: a\n---\nalpha content here for testing");
+  const b = skillFingerprint("---\nname: b\n---\nbeta content here for testing");
+  assert.notEqual(a, b);
+});
+
+test("skillFingerprint ignores frontmatter differences when body is identical", () => {
+  const skillA = "---\nname: tang-foo\nsource_match: m1\n---\nbody content";
+  const skillB = "---\nname: tang-foo\nsource_match: m2\n---\nbody content";
+  assert.equal(skillFingerprint(skillA), skillFingerprint(skillB));
+});
+
+// ── jaccardSimilarity ─────────────────────────────────────────────────────────
+
+test("jaccardSimilarity returns 1 for identical strings", () => {
+  const norm = "dispatch grain inspectors immediately famine relief protocol";
+  assert.equal(jaccardSimilarity(norm, norm), 1);
+});
+
+test("jaccardSimilarity returns 0 for completely different strings", () => {
+  const a = "agriculture famine drought relief grain inspectors";
+  const b = "naval warfare fleet admiral battle formation";
+  const sim = jaccardSimilarity(a, b);
+  assert.ok(sim < 0.1, `expected near-0, got ${sim}`);
+});
+
+test("jaccardSimilarity is in [0,1]", () => {
+  const a = "alpha beta gamma delta epsilon famine grain relief province";
+  const b = "alpha beta omega theta sigma grain province military defense";
+  const sim = jaccardSimilarity(a, b);
+  assert.ok(sim >= 0 && sim <= 1, `out of range: ${sim}`);
+});
+
+test("jaccardSimilarity ignores words ≤ 3 chars (noise words)", () => {
+  // "the", "of", "and", "to" are all ≤3 chars — should be ignored
+  const a = "the of and to a an in on";
+  const b = "foo bar baz qux quux";
+  // Both become empty sets after filtering → similarity = 1
+  assert.equal(jaccardSimilarity(a, b), 0);
+});
+
+// ── findDuplicate ─────────────────────────────────────────────────────────────
+
+function makeTempSkillsDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "civagent-sq-test-"));
+}
+
+function writeSkill(dir, filename, content) {
+  fs.writeFileSync(path.join(dir, filename), content, "utf8");
+}
+
+test("findDuplicate returns null when directory is empty", () => {
+  const dir = makeTempSkillsDir();
+  try {
+    assert.equal(findDuplicate(SAMPLE_SKILL, dir), null);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("findDuplicate detects exact duplicate by fingerprint", () => {
+  const dir = makeTempSkillsDir();
+  try {
+    writeSkill(dir, "learned-2024-01-01-famine-abc123.md", SAMPLE_SKILL);
+    const dup = findDuplicate(SAMPLE_SKILL, dir);
+    assert.equal(dup, "learned-2024-01-01-famine-abc123.md");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("findDuplicate detects near-duplicate above Jaccard threshold", () => {
+  const dir = makeTempSkillsDir();
+  // Slightly modified but highly similar skill
+  const similar = SAMPLE_SKILL.replace(
+    "Dispatch grain inspectors within 48 hours.",
+    "Dispatch grain inspectors within 24 hours."
+  );
+  try {
+    writeSkill(dir, "learned-2024-01-01-famine-abc123.md", SAMPLE_SKILL);
+    const dup = findDuplicate(similar, dir);
+    assert.equal(dup, "learned-2024-01-01-famine-abc123.md");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("findDuplicate returns null for genuinely different skill", () => {
+  const dir = makeTempSkillsDir();
+  const different = `---
+name: tang-naval-warfare
+type: learned
+civ: china/tang
+---
+# Naval Warfare Strategy
+## Trigger
+When a coastal province reports enemy fleet movements.
+## Pattern
+- Mobilise the Yangtze River Fleet within three days.
+- Establish coastal watchtowers every fifty li.
+- Negotiate with allied river clans for supply lines.
+## Example
+Tang responded to southern piracy by doubling the river fleet in 720.`;
+
+  try {
+    writeSkill(dir, "learned-2024-01-01-famine-abc123.md", SAMPLE_SKILL);
+    const dup = findDuplicate(different, dir);
+    assert.equal(dup, null);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("findDuplicate returns null when skills dir does not exist", () => {
+  assert.equal(findDuplicate(SAMPLE_SKILL, "/nonexistent/path/skills"), null);
+});
+
+// ── analyzeSkillsDir ──────────────────────────────────────────────────────────
+
+const SKILL_B = `---
+name: tang-naval-warfare
+type: learned
+civ: china/tang
+---
+# Naval Warfare Strategy
+## Trigger
+When a coastal province reports enemy fleet movements along the southern sea.
+## Pattern
+- Mobilise the Yangtze River Fleet within three days of receiving the alert.
+- Establish coastal watchtowers every fifty li along the shore.
+- Negotiate with allied river clans for supply lines and intelligence.
+## Example
+Tang responded to piracy by doubling the river fleet in 720 AD.`;
+
+test("analyzeSkillsDir returns zeros for missing directory", () => {
+  const result = analyzeSkillsDir("/nonexistent/path/skills");
+  assert.equal(result.total, 0);
+  assert.equal(result.duplicateGroups.length, 0);
+  assert.equal(result.stats.duplicateCount, 0);
+});
+
+test("analyzeSkillsDir counts files and finds no duplicates in distinct skills", () => {
+  const dir = makeTempSkillsDir();
+  try {
+    writeSkill(dir, "learned-2024-01-01-famine-aa1111.md", SAMPLE_SKILL);
+    writeSkill(dir, "learned-2024-01-02-naval-bb2222.md", SKILL_B);
+    const result = analyzeSkillsDir(dir);
+    assert.equal(result.total, 2);
+    assert.equal(result.duplicateGroups.length, 0);
+    assert.equal(result.stats.duplicateCount, 0);
+    assert.ok(result.uniqueTopics.length > 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("analyzeSkillsDir groups near-duplicate skills", () => {
+  const dir = makeTempSkillsDir();
+  const nearlySame = SAMPLE_SKILL.replace("48 hours", "72 hours");
+  try {
+    writeSkill(dir, "learned-2024-01-01-famine-aa1111.md", SAMPLE_SKILL);
+    writeSkill(dir, "learned-2024-01-02-famine-bb2222.md", nearlySame);
+    writeSkill(dir, "learned-2024-01-03-naval-cc3333.md", SKILL_B);
+    const result = analyzeSkillsDir(dir);
+    assert.equal(result.total, 3);
+    assert.equal(result.duplicateGroups.length, 1);
+    assert.equal(result.duplicateGroups[0].length, 2);
+    assert.equal(result.stats.duplicateCount, 1); // one extra copy
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("analyzeSkillsDir extracts firstSedimented and lastSedimented from filenames", () => {
+  const dir = makeTempSkillsDir();
+  try {
+    writeSkill(dir, "learned-2024-01-10-famine-aa1111.md", SAMPLE_SKILL);
+    writeSkill(dir, "learned-2024-03-20-naval-bb2222.md", SKILL_B);
+    const result = analyzeSkillsDir(dir);
+    assert.equal(result.stats.firstSedimented, "2024-01-10");
+    assert.equal(result.stats.lastSedimented,  "2024-03-20");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/tournament.test.mjs
+++ b/test/tournament.test.mjs
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseCiv, civSpawnSpec } from "../engine/v5/tournament.mjs";
+import fs from "node:fs";
+import { parseCiv, civSpawnSpec, buildJudgePrompt } from "../engine/v5/tournament.mjs";
+import { matchDir } from "../engine/v5/events.mjs";
 
 test("parseCiv handles plain regime and regime#backend", () => {
   assert.deepEqual(parseCiv("china/tang"), { regime: "china/tang", backend: "native" });
@@ -32,4 +34,19 @@ test("each civ gets its own match id via env — no shared mutable state", () =>
   const b = civSpawnSpec({ regime: "china/qin", backend: "native", matchId: "T__china-qin" });
   assert.notEqual(a.env.CIVAGENT_MATCH_ID, b.env.CIVAGENT_MATCH_ID);
   assert.equal(a.env.CIVAGENT_MATCH_ID, "T__china-tang");
+});
+
+test("buildJudgePrompt hides backend from blind-eval section headers", () => {
+  const matchId = "test-tournament-prompt-backend-hidden";
+  try {
+    const prompt = buildJudgePrompt("task", [
+      { regime: "china/qin", backend: "cn:doubao", matchId, code: 0, logFile: "/no/such/log" },
+    ]);
+
+    assert.ok(prompt.includes("### china/qin (exit 0)"));
+    assert.ok(!prompt.includes("backend cn:doubao"));
+    assert.ok(!prompt.includes("cn:doubao"));
+  } finally {
+    fs.rmSync(matchDir(matchId), { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- **`multi-judge.mjs`** — blind multi-judge aggregation: civ names anonymized to Civ-A/B/C before each judge sees transcripts; scores parsed from three Markdown table formats and averaged across N providers; de-anonymizes back to regime ids in the final result. Never touches Gemini.
- **`skill-quality.mjs`** — deterministic dedup (zero LLM calls): SHA-256 fingerprint for exact matches, Jaccard similarity (threshold 0.6, words >3 chars) for near-duplicates; `analyzeSkillsDir` quality report with dup groups, unique topics, and sedimentation dates.
- **`replay.mjs`** — re-run any past match: reads original `meta.json`, mints a `replay-*` matchId with `replayOf` lineage, spawns `run-v5.mjs` with injectable `_spawn`/`_runV5` for deterministic tests.
- **`governance-scenarios.json`** — 10 curated challenge scenarios (military, political, economic, diplomatic, crisis) for `--prompt-bank`.
- **`skill-sediment.mjs`** — near-duplicate gate added before writing a skill file.
- **`tournament.mjs`** — multi-judge + prompt-bank wired in; judge logic refactored into `buildJudgePrompt`/`judgeSingle`/`judgeMulti`; `pickScenario()` for `--prompt-bank`.
- **`bin/civagent`** — `replay` subcommand, `skills --stats`, `tournament --multi-judge / --judges N / --prompt-bank / --seed N`.

## Test plan

- [x] `npm run lint:syntax` — all engine files + bash syntax clean
- [x] `npm test` — 69/69 pass (was 32; +11 multi-judge, +16 skill-quality, +7 replay)
- [ ] Codex review requested on this PR