### PR TITLE
feat(frontend): add R2 regime visualization browser

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { Zap, History, BookOpen, Play, Cpu } from 'lucide-react';
+import { Zap, History, BookOpen, Play, Cpu, Layers } from 'lucide-react';
 import type { RegimeDetail, MatchSummary, MatchEvent } from './types/api';
 import TerminalPanel from './components/TerminalPanel';
 import JudgeLeaderboard from './components/JudgeLeaderboard';
 import HistoryExplorer from './components/HistoryExplorer';
 import CodexBrowser from './components/CodexBrowser';
+import RegimeBrowser from './components/RegimeBrowser';
 
 // Premium Simulated Data for Sandbox Mode
 const MOCK_PROMPT = "Establish secure and robust border defense policies for agricultural frontiers facing seasonal tribal raids.";
@@ -84,7 +85,7 @@ const MOCK_JUDGE_VERDICTS = {
 };
 
 export const App: React.FC = () => {
-  const [activeTab, setActiveTab] = useState<'live' | 'history' | 'codex'>('live');
+  const [activeTab, setActiveTab] = useState<'live' | 'history' | 'codex' | 'regimes'>('live');
   const [regimes, setRegimes] = useState<RegimeDetail[]>([]);
   const [matches, setMatches] = useState<MatchSummary[]>([]);
   const [selectedMatch, setSelectedMatch] = useState<MatchSummary | null>(null);
@@ -295,6 +296,18 @@ export const App: React.FC = () => {
           >
             <BookOpen size={14} /> Regimes Codex
           </button>
+
+          <button
+            onClick={() => setActiveTab('regimes')}
+            className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg border text-xs font-semibold uppercase tracking-wider transition-all ${
+              activeTab === 'regimes'
+                ? 'bg-[rgba(0,240,255,0.06)] border-[rgba(0,240,255,0.3)] text-[var(--accent-cyan)] shadow-[0_0_12px_rgba(0,240,255,0.05)]'
+                : 'bg-transparent border-transparent text-[var(--text-secondary)] hover:bg-[rgba(255,255,255,0.02)]'
+            }`}
+            style={{ display: 'flex', alignItems: 'center', gap: '12px', fontSize: '11px', fontWeight: 600, padding: '12px 16px', textAlign: 'left' }}
+          >
+            <Layers size={14} /> Regimes Browser
+          </button>
         </nav>
 
         {/* Footer info */}
@@ -413,6 +426,11 @@ export const App: React.FC = () => {
           {/* TAB 3: REGIMES CODEX */}
           {activeTab === 'codex' && (
             <CodexBrowser regimes={regimes} />
+          )}
+
+          {/* TAB 4: REGIMES BROWSER */}
+          {activeTab === 'regimes' && (
+            <RegimeBrowser regimes={regimes} />
           )}
 
         </div>

--- a/frontend/src/components/RegimeBrowser.tsx
+++ b/frontend/src/components/RegimeBrowser.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { Users, BarChart3, Network, Scroll } from 'lucide-react';
+import type { RegimeDetail } from '../types/api';
+import OrgChart from './regime/OrgChart';
+import ModeComparison from './regime/ModeComparison';
+import RelationshipNetwork from './regime/RelationshipNetwork';
+
+interface RegimeBrowserProps {
+  regimes: RegimeDetail[];
+}
+
+export const RegimeBrowser: React.FC<RegimeBrowserProps> = ({ regimes }) => {
+  const [selectedSubTab, setSelectedSubTab] = useState<'org' | 'comparison' | 'network'>('org');
+  const [selectedRegime, setSelectedRegime] = useState<RegimeDetail | null>(regimes[0] || null);
+
+  // Set default selected regime if none is selected yet and regimes array loads
+  React.useEffect(() => {
+    if (!selectedRegime && regimes.length > 0) {
+      setSelectedRegime(regimes[0]);
+    }
+  }, [regimes, selectedRegime]);
+
+  return (
+    <div className="space-y-6 flex flex-col h-full animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      
+      {/* Sub Tabs Selection Bar */}
+      <div className="glass-panel p-4 flex items-center justify-between gap-4 shrink-0" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '16px', borderRadius: '12px' }}>
+        
+        {/* Info label */}
+        <div className="flex items-center gap-2" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <div className="flex items-center justify-center w-8 h-8 rounded bg-[rgba(0,240,255,0.08)] border border-[rgba(0,240,255,0.2)] text-[var(--accent-cyan)] shadow-[0_0_10px_rgba(0,240,255,0.05)]" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Scroll size={15} />
+          </div>
+          <div>
+            <h2 className="text-sm font-bold uppercase tracking-wider text-[var(--text-primary)]" style={{ fontSize: '13px', fontWeight: 700 }}>
+              Regime Visualization Browser
+            </h2>
+            <span className="text-[10px] text-[var(--text-secondary)] font-mono block">
+              Form ②: Comparative academic analysis of 57 historical systems
+            </span>
+          </div>
+        </div>
+
+        {/* Tab Buttons */}
+        <div className="flex gap-2" style={{ display: 'flex', gap: '8px' }}>
+          
+          <button
+            onClick={() => setSelectedSubTab('org')}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg border text-xs font-semibold uppercase tracking-wider transition-all ${
+              selectedSubTab === 'org'
+                ? 'bg-[var(--accent-cyan)] text-black border-[var(--accent-cyan)] shadow-[0_0_10px_rgba(0,240,255,0.25)]'
+                : 'bg-[rgba(255,255,255,0.02)] border-[rgba(255,255,255,0.05)] text-[var(--text-secondary)] hover:border-[rgba(255,255,255,0.12)]'
+            }`}
+            style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '10px', fontWeight: 600 }}
+          >
+            <Users size={14} /> Org Chart
+          </button>
+
+          <button
+            onClick={() => setSelectedSubTab('comparison')}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg border text-xs font-semibold uppercase tracking-wider transition-all ${
+              selectedSubTab === 'comparison'
+                ? 'bg-[var(--accent-cyan)] text-black border-[var(--accent-cyan)] shadow-[0_0_10px_rgba(0,240,255,0.25)]'
+                : 'bg-[rgba(255,255,255,0.02)] border-[rgba(255,255,255,0.05)] text-[var(--text-secondary)] hover:border-[rgba(255,255,255,0.12)]'
+            }`}
+            style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '10px', fontWeight: 600 }}
+          >
+            <BarChart3 size={14} /> Pattern Comparison
+          </button>
+
+          <button
+            onClick={() => setSelectedSubTab('network')}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg border text-xs font-semibold uppercase tracking-wider transition-all ${
+              selectedSubTab === 'network'
+                ? 'bg-[var(--accent-cyan)] text-black border-[var(--accent-cyan)] shadow-[0_0_10px_rgba(0,240,255,0.25)]'
+                : 'bg-[rgba(255,255,255,0.02)] border-[rgba(255,255,255,0.05)] text-[var(--text-secondary)] hover:border-[rgba(255,255,255,0.12)]'
+            }`}
+            style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '10px', fontWeight: 600 }}
+          >
+            <Network size={14} /> Relationship Network
+          </button>
+
+        </div>
+
+      </div>
+
+      {/* Central Viewport */}
+      <div className="flex-1 overflow-hidden" style={{ flex: 1, overflow: 'hidden' }}>
+        {selectedSubTab === 'org' && (
+          <OrgChart
+            regimes={regimes}
+            selectedRegime={selectedRegime}
+            onSelectRegime={setSelectedRegime}
+          />
+        )}
+
+        {selectedSubTab === 'comparison' && (
+          <ModeComparison regimes={regimes} />
+        )}
+
+        {selectedSubTab === 'network' && (
+          <RelationshipNetwork regimes={regimes} />
+        )}
+      </div>
+
+    </div>
+  );
+};
+export default RegimeBrowser;

--- a/frontend/src/components/regime/ModeComparison.tsx
+++ b/frontend/src/components/regime/ModeComparison.tsx
@@ -1,0 +1,240 @@
+import React, { useState } from 'react';
+import { BarChart3, ChevronDown, ChevronUp } from 'lucide-react';
+import type { RegimeDetail } from '../../types/api';
+
+interface ModeComparisonProps {
+  regimes: RegimeDetail[];
+}
+
+interface PatternInfo {
+  id: string;
+  zhName: string;
+  enName: string;
+  description: string;
+  color: string;
+  borderColor: string;
+}
+
+const PATTERNS_CATALOG: PatternInfo[] = [
+  {
+    id: 'centralized',
+    zhName: '星型中央集权制',
+    enName: 'Centralized Star Topology',
+    description: '由中心单一协调者直接下达指令、直辖所有执行节点，决策效率与执行速度极高，但缺乏容错与分布式制衡。',
+    color: 'rgba(255, 46, 147, 0.08)',
+    borderColor: 'rgba(255, 46, 147, 0.35)',
+  },
+  {
+    id: 'checks-and-balances',
+    zhName: '分权制衡管道制',
+    enName: 'Checks & Balances Pipeline',
+    description: '采用起草、审核、执行等管道式级联流程与否决权反馈环，具有高度容错与纠错机制，适用于重特大高危决策。',
+    color: 'rgba(255, 215, 0, 0.08)',
+    borderColor: 'rgba(255, 215, 0, 0.35)',
+  },
+  {
+    id: 'democratic',
+    zhName: '民主合议投票制',
+    enName: 'Democratic Voting Consensus',
+    description: '平行多智能体协作合议，通过多种投票计票表决算法汇聚共识，重视过程正当性与偏好分散对齐。',
+    color: 'rgba(0, 240, 255, 0.08)',
+    borderColor: 'rgba(0, 240, 255, 0.35)',
+  },
+  {
+    id: 'dual-track',
+    zhName: '双轨相互独立制',
+    enName: 'Dual-Track Redundancy',
+    description: '两条或多条互相独立的平行执行/决策链条并行，提供高度的信息冗余、独立监管与决策双向热备份。',
+    color: 'rgba(189, 0, 255, 0.08)',
+    borderColor: 'rgba(189, 0, 255, 0.35)',
+  },
+  {
+    id: 'federation',
+    zhName: '联邦分布式自治',
+    enName: 'Federation Decentralization',
+    description: '中心协调枢纽与各异构自治子节点并存，极具弹性，适用于局部高度专业化与高度差异性的分布式场景。',
+    color: 'rgba(57, 255, 20, 0.08)',
+    borderColor: 'rgba(57, 255, 20, 0.35)',
+  },
+  {
+    id: 'theocratic',
+    zhName: '神权对齐解释制',
+    enName: 'Theocratic Alignment Hierarchy',
+    description: '基于一致性最高宪法/原则，带有单一神学或终极解释权的层级治理，确保执行层绝对信仰与价值对齐。',
+    color: 'rgba(251, 191, 36, 0.08)',
+    borderColor: 'rgba(251, 191, 36, 0.35)',
+  },
+];
+
+export const ModeComparison: React.FC<ModeComparisonProps> = ({ regimes }) => {
+  const [expandedPattern, setExpandedPattern] = useState<string | null>(null);
+
+  // Group regimes by pattern
+  const getRegimesByPattern = (patternId: string) => {
+    return regimes.filter(r => r.metadata?.orchestrationPattern === patternId);
+  };
+
+  // Get max count for chart scaling
+  const maxCount = Math.max(...PATTERNS_CATALOG.map(p => getRegimesByPattern(p.id).length), 1);
+
+  const toggleExpand = (patternId: string) => {
+    if (expandedPattern === patternId) {
+      setExpandedPattern(null);
+    } else {
+      setExpandedPattern(patternId);
+    }
+  };
+
+  return (
+    <div className="space-y-6 overflow-y-auto max-h-[500px] pr-2 scroll-fade-y animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxHeight: '500px', overflowY: 'auto' }}>
+      
+      {/* Top Section: Quick bar chart */}
+      <div className="glass-panel p-5 bg-[rgba(10,11,16,0.35)] border-[rgba(255,255,255,0.05)] rounded-xl" style={{ padding: '20px', borderRadius: '12px', border: '1px solid rgba(255,255,255,0.05)', background: 'rgba(10,11,16,0.35)' }}>
+        <div className="flex items-center gap-2 mb-4 text-[var(--accent-cyan)] font-heading" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--accent-cyan)', marginBottom: '16px' }}>
+          <BarChart3 size={15} />
+          <h4 className="text-xs font-bold uppercase tracking-wider">
+            CANONICAL ORCHESTRATION DISTRIBUTION
+          </h4>
+        </div>
+
+        {/* Dynamic bar charts */}
+        <div className="space-y-3.5" style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+          {PATTERNS_CATALOG.map((p) => {
+            const list = getRegimesByPattern(p.id);
+            const percent = ((list.length / maxCount) * 100).toFixed(0);
+            
+            return (
+              <div key={p.id} className="space-y-1.5" style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                <div className="flex items-center justify-between text-xs font-semibold text-[var(--text-secondary)]" style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px' }}>
+                  <span>{p.zhName} ({p.id})</span>
+                  <span className="font-mono">{list.length} Regimes ({percent}%)</span>
+                </div>
+                {/* Visual Bar container */}
+                <div className="w-full bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.04)] h-3 rounded-full overflow-hidden" style={{ width: '100%', height: '12px', backgroundColor: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.04)', borderRadius: '999px' }}>
+                  <div
+                    className="h-full rounded-full transition-all duration-500"
+                    style={{
+                      width: `${percent}%`,
+                      height: '100%',
+                      background: `linear-gradient(to right, ${p.borderColor.replace('0.35', '0.2')}, ${p.borderColor.replace('0.35', '0.8')})`,
+                      boxShadow: `0 0 10px ${p.borderColor.replace('0.35', '0.4')}`
+                    }}
+                  ></div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Mode Cards Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-5" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '20px' }}>
+        {PATTERNS_CATALOG.map((p) => {
+          const list = getRegimesByPattern(p.id);
+          const isExpanded = expandedPattern === p.id;
+
+          return (
+            <div
+              key={p.id}
+              className="glass-panel p-5 flex flex-col justify-between transition-all"
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
+                padding: '20px',
+                borderRadius: '12px',
+                backgroundColor: p.color,
+                borderColor: p.borderColor,
+                boxShadow: `0 0 15px ${p.borderColor.replace('0.35', '0.04')}`
+              }}
+            >
+              <div className="space-y-3" style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                {/* Header */}
+                <div className="flex items-center justify-between" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div>
+                    <h3 className="text-sm font-bold text-[var(--text-primary)]" style={{ fontSize: '14px', fontWeight: 700 }}>
+                      {p.zhName}
+                    </h3>
+                    <span className="text-[10px] font-mono text-[var(--text-muted)] uppercase tracking-wider block">
+                      {p.enName}
+                    </span>
+                  </div>
+                  <span
+                    className="w-7 h-7 rounded-full flex items-center justify-center font-bold text-xs"
+                    style={{
+                      width: '28px',
+                      height: '28px',
+                      borderRadius: '50%',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: 'rgba(255,255,255,0.03)',
+                      border: `1px solid ${p.borderColor}`,
+                      color: p.borderColor.replace('0.35', '1')
+                    }}
+                  >
+                    {list.length}
+                  </span>
+                </div>
+
+                {/* Description */}
+                <p className="text-xs text-[var(--text-secondary)] leading-relaxed" style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: '1.6' }}>
+                  {p.description}
+                </p>
+              </div>
+
+              {/* Collapsible Regimes trigger */}
+              <div className="border-t border-[rgba(255,255,255,0.05)] pt-3.5 mt-5" style={{ borderTop: '1px solid rgba(255,255,255,0.05)', paddingTop: '14px', marginTop: '20px' }}>
+                <button
+                  onClick={() => toggleExpand(p.id)}
+                  className="flex items-center gap-1 text-[10px] font-bold text-[var(--text-muted)] hover:text-white uppercase tracking-wider"
+                  style={{ display: 'flex', alignItems: 'center', gap: '4px', fontSize: '10px', fontWeight: 700, background: 'none', border: 'none' }}
+                >
+                  {isExpanded ? (
+                    <>
+                      Hide Regimes <ChevronUp size={12} />
+                    </>
+                  ) : (
+                    <>
+                      Show Mapped Regimes ({list.length}) <ChevronDown size={12} />
+                    </>
+                  )}
+                </button>
+
+                {/* Expanded list of chips */}
+                {isExpanded && (
+                  <div className="flex flex-wrap gap-1.5 mt-3 animate-fade-in" style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginTop: '12px' }}>
+                    {list.map((r) => {
+                      const name = r.id.split('/').pop()?.replace('-', ' ') || '';
+                      const isChina = r.metadata?.region === 'china';
+
+                      return (
+                        <span
+                          key={r.id}
+                          className="text-[9px] px-2 py-0.5 rounded font-mono border"
+                          style={{
+                            fontSize: '9px',
+                            padding: '3px 8px',
+                            borderRadius: '4px',
+                            backgroundColor: 'rgba(0,0,0,0.25)',
+                            borderColor: isChina ? 'rgba(0,240,255,0.15)' : 'rgba(189,0,255,0.15)',
+                            color: isChina ? 'var(--accent-cyan)' : '#d8b4fe'
+                          }}
+                        >
+                          {name}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+            </div>
+          );
+        })}
+      </div>
+
+    </div>
+  );
+};
+export default ModeComparison;

--- a/frontend/src/components/regime/OrgChart.tsx
+++ b/frontend/src/components/regime/OrgChart.tsx
@@ -1,0 +1,322 @@
+import React, { useEffect, useState } from 'react';
+import { ShieldAlert, Users, Award, Loader2 } from 'lucide-react';
+import type { RegimeDetail } from '../../types/api';
+import type { IdentityRole, IdentityData } from '../../types/regime';
+
+interface OrgChartProps {
+  regimes: RegimeDetail[];
+  selectedRegime: RegimeDetail | null;
+  onSelectRegime: (regime: RegimeDetail) => void;
+}
+
+export const OrgChart: React.FC<OrgChartProps> = ({
+  regimes,
+  selectedRegime,
+  onSelectRegime,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [roles, setRoles] = useState<IdentityRole[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Fetch identity MD whenever active regime changes
+  useEffect(() => {
+    if (!selectedRegime) {
+      setRoles([]);
+      return;
+    }
+
+    const fetchIdentity = async () => {
+      setLoading(true);
+      try {
+        const parts = selectedRegime.id.split('/');
+        const region = parts[0];
+        const id = parts[1];
+        
+        const res = await fetch(`/api/regimes/${region}/${id}/identity`);
+        if (res.ok) {
+          const data: IdentityData = await res.json();
+          
+          if (data.raw) {
+            const parsed = parseIdentityRoles(data.raw);
+            setRoles(parsed);
+          } else {
+            setRoles([]);
+          }
+        }
+      } catch (e) {
+        console.error('Failed to fetch identity MD:', e);
+        setRoles([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchIdentity();
+  }, [selectedRegime]);
+
+  // Parse markdown roles table
+  const parseIdentityRoles = (rawMarkdown: string): IdentityRole[] => {
+    const lines = rawMarkdown.split('\n');
+    const parsedRoles: IdentityRole[] = [];
+    let inTable = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('|') && trimmed.endsWith('|')) {
+        const parts = trimmed.split('|').map(p => p.trim()).filter(Boolean);
+        
+        // Header detection
+        if (trimmed.toLowerCase().includes('agent id') || trimmed.toLowerCase().includes('ai 职责')) {
+          inTable = true;
+          continue;
+        }
+        
+        // Split separator
+        if (trimmed.includes('---')) {
+          continue;
+        }
+        
+        if (inTable && parts.length >= 3) {
+          parsedRoles.push({
+            roleName: parts[0] || '',
+            agentId: (parts[1] || '').replace(/`/g, ''),
+            responsibility: parts[2] || '',
+            model: (parts[3] || '').replace(/`/g, ''),
+          });
+        }
+      }
+    }
+    return parsedRoles;
+  };
+
+  // Group regimes for sidebar listing
+  const filteredRegimes = regimes.filter(r => 
+    r.id.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const chinaRegimes = filteredRegimes.filter(r => r.metadata?.region === 'china');
+  const globalRegimes = filteredRegimes.filter(r => r.metadata?.region === 'global');
+
+  // Segregate roles into Coordinator (Emperor/Consul/Gensec) and Executors
+  const coordinatorRole = roles.find(r => 
+    r.responsibility.toLowerCase().includes('coordinator') || 
+    r.responsibility.toLowerCase().includes('起草') || 
+    r.responsibility.toLowerCase().includes('总管') ||
+    r.responsibility.toLowerCase().includes('调度')
+  ) || roles[0];
+
+  const executorRoles = roles.filter(r => r.agentId !== coordinatorRole?.agentId);
+
+  const getRoleBadgeStyle = (resp: string) => {
+    const r = resp.toLowerCase();
+    if (r.includes('review') || r.includes('审核') || r.includes('监察')) return 'role-review';
+    if (r.includes('code') || r.includes('开发') || r.includes('工程')) return 'role-engineering';
+    if (r.includes('devops') || r.includes('运维') || r.includes('部署')) return 'role-devops';
+    return 'role-management';
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-4 gap-6" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '24px' }}>
+      
+      {/* Sidebar - Regimes Selector */}
+      <div className="lg:col-span-1 glass-panel p-5 flex flex-col h-[540px] overflow-hidden" style={{ gridColumn: 'span 1', display: 'flex', flexDirection: 'column', height: '540px', padding: '20px', borderRadius: '12px' }}>
+        
+        {/* Search */}
+        <div className="mb-4 shrink-0" style={{ marginBottom: '16px' }}>
+          <input
+            type="text"
+            placeholder="Search regimes..."
+            className="w-full text-xs"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            style={{ width: '100%', fontSize: '12px' }}
+          />
+        </div>
+
+        {/* List scroll */}
+        <div className="flex-1 overflow-y-auto space-y-4 pr-1 scroll-fade-y" style={{ flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          
+          {/* China Dynasties */}
+          {chinaRegimes.length > 0 && (
+            <div className="space-y-1.5" style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <span className="text-[10px] text-cyan-400 font-mono font-bold uppercase tracking-wider block" style={{ display: 'block', fontSize: '10px' }}>
+                CHINA DYNASTIES ({chinaRegimes.length})
+              </span>
+              <div className="space-y-1" style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                {chinaRegimes.map((r) => (
+                  <button
+                    key={r.id}
+                    onClick={() => onSelectRegime(r)}
+                    className={`w-full text-left px-3 py-2 rounded-lg text-xs font-semibold tracking-wide border transition-all ${
+                      selectedRegime?.id === r.id
+                        ? 'bg-[rgba(0,240,255,0.06)] border-[rgba(0,240,255,0.3)] text-[var(--accent-cyan)] shadow-[0_0_8px_rgba(0,240,255,0.05)]'
+                        : 'bg-transparent border-transparent text-[var(--text-secondary)] hover:bg-[rgba(255,255,255,0.02)]'
+                    }`}
+                    style={{ fontSize: '11px', textAlign: 'left', padding: '8px 12px' }}
+                  >
+                    {r.id.split('/').pop()?.replace('-', ' ')}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Global Empires */}
+          {globalRegimes.length > 0 && (
+            <div className="space-y-1.5" style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <span className="text-[10px] text-purple-400 font-mono font-bold uppercase tracking-wider block" style={{ display: 'block', fontSize: '10px' }}>
+                GLOBAL EMPIRES ({globalRegimes.length})
+              </span>
+              <div className="space-y-1" style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                {globalRegimes.map((r) => (
+                  <button
+                    key={r.id}
+                    onClick={() => onSelectRegime(r)}
+                    className={`w-full text-left px-3 py-2 rounded-lg text-xs font-semibold tracking-wide border transition-all ${
+                      selectedRegime?.id === r.id
+                        ? 'bg-[rgba(0,240,255,0.06)] border-[rgba(0,240,255,0.3)] text-[var(--accent-cyan)] shadow-[0_0_8px_rgba(0,240,255,0.05)]'
+                        : 'bg-transparent border-transparent text-[var(--text-secondary)] hover:bg-[rgba(255,255,255,0.02)]'
+                    }`}
+                    style={{ fontSize: '11px', textAlign: 'left', padding: '8px 12px' }}
+                  >
+                    {r.id.split('/').pop()?.replace('-', ' ')}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+        </div>
+
+      </div>
+
+      {/* Main Org Chart Workspace */}
+      <div className="lg:col-span-3 glass-panel p-6 flex flex-col h-[540px] overflow-hidden" style={{ gridColumn: 'span 3', display: 'flex', flexDirection: 'column', height: '540px', padding: '24px', borderRadius: '12px' }}>
+        {selectedRegime ? (
+          <div className="flex flex-col h-full overflow-hidden" style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+            
+            {/* Header */}
+            <div className="flex items-center justify-between pb-3 border-b border-[rgba(255,255,255,0.06)] shrink-0" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '1px solid rgba(255,255,255,0.06)', paddingBottom: '12px' }}>
+              <div>
+                <h3 className="text-base font-bold text-[var(--text-primary)] uppercase tracking-wider" style={{ fontSize: '16px', fontWeight: 700 }}>
+                  {selectedRegime.id.split('/').pop()?.replace('-', ' ')} Organizational Architecture
+                </h3>
+                <span className="text-[10px] text-[var(--text-secondary)] font-mono block">
+                  EPOCH: {selectedRegime.metadata?.era?.en || 'Ancient'} · PATTERN: {selectedRegime.metadata?.orchestrationPattern}
+                </span>
+              </div>
+              <span className="live-badge">Form ② Viz</span>
+            </div>
+
+            {/* Tree Flow / Content Workspace */}
+            <div className="flex-1 overflow-y-auto p-4 mt-4 relative" style={{ flex: 1, overflowY: 'auto', marginTop: '16px' }}>
+              {loading ? (
+                <div className="flex flex-col items-center justify-center h-full gap-3 text-[var(--text-muted)]" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: '12px' }}>
+                  <Loader2 className="animate-spin text-[var(--accent-cyan)]" size={32} />
+                  <span>Compiling historical identity manifests...</span>
+                </div>
+              ) : roles.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-full gap-2 text-[var(--text-muted)]" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: '8px' }}>
+                  <ShieldAlert size={36} className="text-[rgba(255,255,255,0.1)]" />
+                  <span>IDENTITY.md role mappings not loaded or empty.</span>
+                </div>
+              ) : (
+                <div className="space-y-8 animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: '32px' }}>
+                  
+                  {/* CSS Hierarchical Flow diagram */}
+                  <div className="flex flex-col items-center" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                    
+                    {/* Coordinator (Emperor/Consul/General Sec) */}
+                    {coordinatorRole && (
+                      <div className="glass-panel glass-panel-gold p-4 text-center max-w-[280px]" style={{ padding: '14px', border: '1px solid var(--accent-gold)', borderRadius: '12px', textAlign: 'center', width: '280px' }}>
+                        <span className="text-[9px] text-amber-400 font-bold block mb-1 font-heading uppercase tracking-wider flex items-center justify-center gap-1">
+                          <Award size={11} fill="var(--accent-gold)" /> COORDINATOR / DECIDER
+                        </span>
+                        <h4 className="text-sm font-bold text-[var(--text-primary)] mb-0.5">{coordinatorRole.roleName}</h4>
+                        <code className="text-[9px] text-[var(--text-secondary)] font-mono block mb-1.5">{coordinatorRole.agentId}</code>
+                        <p className="text-[11px] text-[var(--text-muted)] leading-relaxed">{coordinatorRole.responsibility}</p>
+                      </div>
+                    )}
+
+                    {/* Vertical connecting line */}
+                    {executorRoles.length > 0 && (
+                      <div style={{ width: '2px', height: '32px', background: 'linear-gradient(to bottom, var(--accent-gold), var(--accent-cyan))' }}></div>
+                    )}
+
+                    {/* Executors Horizontal Grid */}
+                    {executorRoles.length > 0 && (
+                      <div className="flex flex-wrap justify-center gap-4 w-full" style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: '16px', width: '100%' }}>
+                        {executorRoles.map((exec) => (
+                          <div 
+                            key={exec.agentId} 
+                            className="glass-panel p-3.5 text-center w-[210px] hover:border-[rgba(0,240,255,0.25)] relative"
+                            style={{ 
+                              padding: '14px', 
+                              borderRadius: '8px', 
+                              width: '210px', 
+                              textAlign: 'center',
+                              background: 'rgba(18,20,32,0.4)',
+                              border: '1px solid rgba(255,255,255,0.04)'
+                            }}
+                          >
+                            <span className={`role-badge ${getRoleBadgeStyle(exec.responsibility)}`} style={{ fontSize: '8px', padding: '1px 5px', display: 'inline-block', marginBottom: '6px' }}>
+                              {exec.responsibility.includes('Review') || exec.responsibility.includes('审核') ? 'REVIEWER' : 'EXECUTOR'}
+                            </span>
+                            <h5 className="text-xs font-bold text-[var(--text-primary)] mb-0.5">{exec.roleName}</h5>
+                            <code className="text-[9px] text-[var(--text-secondary)] font-mono block mb-1">{exec.agentId}</code>
+                            <p className="text-[10px] text-[var(--text-muted)] leading-relaxed">{exec.responsibility}</p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                  </div>
+
+                  {/* Tabular Details Section */}
+                  <div className="glass-panel p-4 bg-[rgba(10,11,16,0.3)] border-[rgba(255,255,255,0.04)] text-xs rounded-lg" style={{ padding: '16px', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.04)', background: 'rgba(10,11,16,0.3)', fontSize: '12px' }}>
+                    <div className="flex items-center gap-2 text-cyan-400 mb-3" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--accent-cyan)', marginBottom: '12px' }}>
+                      <Users size={13} />
+                      <h4 className="font-heading font-bold uppercase tracking-wider text-[10px]">
+                        ROLE MAPPING DETAILS & MODEL HIERARCHY
+                      </h4>
+                    </div>
+
+                    <table className="w-full text-left font-mono text-[11px]" style={{ width: '100%', textAlign: 'left', fontFamily: 'var(--font-mono)', fontSize: '11px', borderCollapse: 'collapse' }}>
+                      <thead>
+                        <tr className="border-b border-[rgba(255,255,255,0.06)] text-[var(--text-muted)]" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+                          <th className="pb-2">Historical Role</th>
+                          <th className="pb-2">Agent ID</th>
+                          <th className="pb-2">AI Responsibility</th>
+                          <th className="pb-2 text-right">Recommended Model</th>
+                        </tr>
+                      </thead>
+                      <tbody className="text-[var(--text-secondary)]">
+                        {roles.map((role) => (
+                          <tr key={role.agentId} className="border-b border-[rgba(255,255,255,0.03)] hover:text-white" style={{ borderBottom: '1px solid rgba(255,255,255,0.03)' }}>
+                            <td className="py-2.5 font-sans font-semibold text-[var(--text-primary)]">{role.roleName}</td>
+                            <td className="py-2.5 text-cyan-300">{role.agentId}</td>
+                            <td className="py-2.5 text-xs font-sans text-[var(--text-secondary)]">{role.responsibility}</td>
+                            <td className="py-2.5 text-right text-purple-300">{role.model || 'Default'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                </div>
+              )}
+            </div>
+
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full text-[var(--text-muted)] gap-3" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%', gap: '12px' }}>
+            <Users size={40} className="text-[rgba(255,255,255,0.1)]" />
+            <span>Select a historical regime from the sidebar to inspect its organizational department structure.</span>
+          </div>
+        )}
+      </div>
+
+    </div>
+  );
+};
+export default OrgChart;

--- a/frontend/src/components/regime/OrgChart.tsx
+++ b/frontend/src/components/regime/OrgChart.tsx
@@ -29,6 +29,12 @@ export const OrgChart: React.FC<OrgChartProps> = ({
       setLoading(true);
       try {
         const parts = selectedRegime.id.split('/');
+        if (parts.length < 2) {
+          console.warn('Invalid selected regime ID format:', selectedRegime.id);
+          setRoles([]);
+          setLoading(false);
+          return;
+        }
         const region = parts[0];
         const id = parts[1];
         
@@ -84,6 +90,9 @@ export const OrgChart: React.FC<OrgChartProps> = ({
             model: (parts[3] || '').replace(/`/g, ''),
           });
         }
+      } else if (inTable) {
+        // Exited table - stop parsing
+        break;
       }
     }
     return parsedRoles;
@@ -97,15 +106,22 @@ export const OrgChart: React.FC<OrgChartProps> = ({
   const chinaRegimes = filteredRegimes.filter(r => r.metadata?.region === 'china');
   const globalRegimes = filteredRegimes.filter(r => r.metadata?.region === 'global');
 
-  // Segregate roles into Coordinator (Emperor/Consul/Gensec) and Executors
-  const coordinatorRole = roles.find(r => 
+  // Segregate roles into Coordinators (Emperor/Consul/Gensec/Co-decision peers) and Executors
+  // Supports multiple peer/co-decision top-level roles (e.g. Council/Parliament/Commission co-decision in global/eu)
+  const coordinatorRoles = roles.filter(r => 
     r.responsibility.toLowerCase().includes('coordinator') || 
     r.responsibility.toLowerCase().includes('起草') || 
     r.responsibility.toLowerCase().includes('总管') ||
-    r.responsibility.toLowerCase().includes('调度')
-  ) || roles[0];
+    r.responsibility.toLowerCase().includes('调度') ||
+    r.responsibility.toLowerCase().includes('co-decision') ||
+    r.responsibility.toLowerCase().includes('decider') ||
+    r.responsibility.toLowerCase().includes('decision-maker') ||
+    r.responsibility.toLowerCase().includes('decision maker')
+  );
 
-  const executorRoles = roles.filter(r => r.agentId !== coordinatorRole?.agentId);
+  const finalCoordinators = coordinatorRoles.length > 0 ? coordinatorRoles : [roles[0]];
+  const coordinatorIds = finalCoordinators.map(c => c.agentId);
+  const executorRoles = roles.filter(r => !coordinatorIds.includes(r.agentId));
 
   const getRoleBadgeStyle = (resp: string) => {
     const r = resp.toLowerCase();
@@ -226,15 +242,30 @@ export const OrgChart: React.FC<OrgChartProps> = ({
                   {/* CSS Hierarchical Flow diagram */}
                   <div className="flex flex-col items-center" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
                     
-                    {/* Coordinator (Emperor/Consul/General Sec) */}
-                    {coordinatorRole && (
-                      <div className="glass-panel glass-panel-gold p-4 text-center max-w-[280px]" style={{ padding: '14px', border: '1px solid var(--accent-gold)', borderRadius: '12px', textAlign: 'center', width: '280px' }}>
-                        <span className="text-[9px] text-amber-400 font-bold block mb-1 font-heading uppercase tracking-wider flex items-center justify-center gap-1">
-                          <Award size={11} fill="var(--accent-gold)" /> COORDINATOR / DECIDER
-                        </span>
-                        <h4 className="text-sm font-bold text-[var(--text-primary)] mb-0.5">{coordinatorRole.roleName}</h4>
-                        <code className="text-[9px] text-[var(--text-secondary)] font-mono block mb-1.5">{coordinatorRole.agentId}</code>
-                        <p className="text-[11px] text-[var(--text-muted)] leading-relaxed">{coordinatorRole.responsibility}</p>
+                    {/* Coordinators Grid (supports single or co-decision peers) */}
+                    {finalCoordinators.length > 0 && (
+                      <div className="flex flex-wrap justify-center gap-4 w-full mb-2" style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: '16px', width: '100%', marginBottom: '8px' }}>
+                        {finalCoordinators.map((coord) => (
+                          <div 
+                            key={coord.agentId}
+                            className="glass-panel glass-panel-gold p-4 text-center w-[250px] relative hover:border-amber-400" 
+                            style={{ 
+                              padding: '14px', 
+                              border: '1px solid var(--accent-gold)', 
+                              borderRadius: '12px', 
+                              textAlign: 'center', 
+                              width: '250px',
+                              background: 'rgba(251,191,36,0.03)'
+                            }}
+                          >
+                            <span className="text-[9px] text-amber-400 font-bold block mb-1 font-heading uppercase tracking-wider flex items-center justify-center gap-1">
+                              <Award size={11} fill="var(--accent-gold)" /> COORDINATOR / DECIDER
+                            </span>
+                            <h4 className="text-sm font-bold text-[var(--text-primary)] mb-0.5">{coord.roleName}</h4>
+                            <code className="text-[9px] text-[var(--text-secondary)] font-mono block mb-1.5">{coord.agentId}</code>
+                            <p className="text-[10px] text-[var(--text-muted)] leading-relaxed">{coord.responsibility}</p>
+                          </div>
+                        ))}
                       </div>
                     )}
 

--- a/frontend/src/components/regime/OrgChart.tsx
+++ b/frontend/src/components/regime/OrgChart.tsx
@@ -116,10 +116,14 @@ export const OrgChart: React.FC<OrgChartProps> = ({
     r.responsibility.toLowerCase().includes('co-decision') ||
     r.responsibility.toLowerCase().includes('decider') ||
     r.responsibility.toLowerCase().includes('decision-maker') ||
-    r.responsibility.toLowerCase().includes('decision maker')
+    r.responsibility.toLowerCase().includes('decision maker') ||
+    r.responsibility.toLowerCase().includes('co-legislat') ||
+    r.responsibility.toLowerCase().includes('proposes legislation') ||
+    r.responsibility.toLowerCase().includes('propose legislation')
   );
 
-  const finalCoordinators = coordinatorRoles.length > 0 ? coordinatorRoles : [roles[0]];
+  const finalCoordinators =
+    coordinatorRoles.length > 0 ? coordinatorRoles : roles.length > 0 ? [roles[0]] : [];
   const coordinatorIds = finalCoordinators.map(c => c.agentId);
   const executorRoles = roles.filter(r => !coordinatorIds.includes(r.agentId));
 

--- a/frontend/src/components/regime/RelationshipNetwork.tsx
+++ b/frontend/src/components/regime/RelationshipNetwork.tsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { HelpCircle, Network } from 'lucide-react';
+import type { RegimeDetail } from '../../types/api';
+
+interface RelationshipNetworkProps {
+  regimes: RegimeDetail[];
+}
+
+export const RelationshipNetwork: React.FC<RelationshipNetworkProps> = ({ regimes }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [hoveredRegime, setHoveredRegime] = useState<RegimeDetail | null>(null);
+  const [connections, setConnections] = useState<Array<{ from: { x: number; y: number }; to: { x: number; y: number }; id: string }>>([]);
+  const [windowWidth, setWindowWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
+
+  // Handle window resize to re-draw connection paths
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  // Update connection curves whenever hovered node changes
+  useEffect(() => {
+    updatePaths();
+  }, [hoveredRegime, windowWidth]);
+
+  const updatePaths = () => {
+    if (!containerRef.current || !hoveredRegime) {
+      setConnections([]);
+      return;
+    }
+
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const fromEl = document.getElementById(`node-${hoveredRegime.id.replace(/\//g, '-')}`);
+    if (!fromEl) return;
+
+    const fromRect = fromEl.getBoundingClientRect();
+    const fromX = fromRect.left - containerRect.left + fromRect.width / 2;
+    const fromY = fromRect.top - containerRect.top + fromRect.height / 2;
+
+    const newConnections: Array<{ from: { x: number; y: number }; to: { x: number; y: number }; id: string }> = [];
+    
+    // Find regimes sharing >= 1 tag
+    const sharedRegimes = regimes.filter(r => 
+      r.id !== hoveredRegime.id && 
+      r.metadata?.tags?.some(t => hoveredRegime.metadata?.tags?.includes(t))
+    );
+
+    sharedRegimes.forEach(r => {
+      const toEl = document.getElementById(`node-${r.id.replace(/\//g, '-')}`);
+      if (toEl) {
+        const toRect = toEl.getBoundingClientRect();
+        const toX = toRect.left - containerRect.left + toRect.width / 2;
+        const toY = toRect.top - containerRect.top + toRect.height / 2;
+        newConnections.push({
+          from: { x: fromX, y: fromY },
+          to: { x: toX, y: toY },
+          id: r.id
+        });
+      }
+    });
+
+    setConnections(newConnections);
+  };
+
+  const chinaRegimes = regimes.filter(r => r.metadata?.region === 'china');
+  const globalRegimes = regimes.filter(r => r.metadata?.region === 'global');
+
+  // Node size scaling positive to agentCount
+  const getNodeSizeStyle = (count?: number) => {
+    const num = count || 5;
+    if (num >= 8) return { scale: 'scale-105', padding: 'px-3 py-1.5', font: 'text-xs' };
+    if (num >= 6) return { scale: 'scale-100', padding: 'px-2.5 py-1', font: 'text-[11px]' };
+    return { scale: 'scale-95', padding: 'px-2 py-0.5', font: 'text-[10px]' };
+  };
+
+  return (
+    <div className="flex flex-col h-[500px] overflow-hidden" style={{ display: 'flex', flexDirection: 'column', height: '500px', overflow: 'hidden' }}>
+      
+      {/* Description header */}
+      <div className="flex items-center justify-between pb-3 border-b border-[rgba(255,255,255,0.06)] shrink-0 mb-4" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '1px solid rgba(255,255,255,0.06)', paddingBottom: '12px', marginBottom: '16px' }}>
+        <div className="flex items-center gap-2 text-[var(--accent-cyan)] font-heading" style={{ display: 'flex', alignItems: 'center', gap: '8px', color: 'var(--accent-cyan)' }}>
+          <Network size={15} />
+          <h4 className="text-xs font-bold uppercase tracking-wider">
+            CIVILIZATION INFLUENCE & SHARED RELATIONSHIP MAP
+          </h4>
+        </div>
+        <span className="text-[10px] text-[var(--text-muted)] italic font-mono flex items-center gap-1" style={{ display: 'inline-flex', alignItems: 'center', gap: '4px', fontSize: '10px' }}>
+          <HelpCircle size={12} /> Hover a node to visualize shared tags linkages
+        </span>
+      </div>
+
+      {/* Network split view */}
+      <div 
+        ref={containerRef}
+        className="flex-1 grid grid-cols-5 gap-4 overflow-hidden relative select-none"
+        style={{ flex: 1, display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: '16px', position: 'relative', overflow: 'hidden' }}
+      >
+        
+        {/* Dynamic SVG connection paths container */}
+        {hoveredRegime && connections.length > 0 && (
+          <svg 
+            className="absolute inset-0 pointer-events-none z-10"
+            style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', pointerEvents: 'none', zIndex: 10 }}
+          >
+            {connections.map((c) => {
+              // Draw a smooth curved Bezier connection path instead of direct rigid lines
+              const midX = (c.from.x + c.to.x) / 2;
+              const pathD = `M ${c.from.x} ${c.from.y} C ${midX} ${c.from.y}, ${midX} ${c.to.y}, ${c.to.x} ${c.to.y}`;
+              
+              return (
+                <g key={c.id}>
+                  {/* Glowing wide backing path */}
+                  <path
+                    d={pathD}
+                    fill="none"
+                    stroke="rgba(0, 240, 255, 0.08)"
+                    strokeWidth={4}
+                  />
+                  {/* Sharp core path */}
+                  <path
+                    d={pathD}
+                    fill="none"
+                    stroke="rgba(0, 240, 255, 0.4)"
+                    strokeWidth={1.5}
+                    strokeDasharray="4 4"
+                    className="animate-dash"
+                    style={{
+                      animation: 'dash 30s linear infinite'
+                    }}
+                  />
+                </g>
+              );
+            })}
+          </svg>
+        )}
+
+        {/* Column 1 & 2: China Dynasties (flex columns) */}
+        <div 
+          className="col-span-2 overflow-y-auto max-h-full space-y-2.5 p-2 bg-[rgba(255,255,255,0.01)] rounded border border-[rgba(255,255,255,0.02)] scroll-fade-y" 
+          style={{ gridColumn: 'span 2', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: '8px', padding: '8px' }}
+        >
+          <span className="text-[9px] text-cyan-400 font-mono font-bold tracking-wider block" style={{ fontSize: '9px' }}>
+            CHINA REGIONS
+          </span>
+          <div className="flex flex-wrap gap-2 align-content-start" style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', alignContent: 'flex-start' }}>
+            {chinaRegimes.map((r) => {
+              const name = r.id.split('/').pop()?.replace('-', ' ') || '';
+              const size = getNodeSizeStyle(r.metadata?.agentCount);
+              const isHovered = hoveredRegime?.id === r.id;
+              const isConnected = connections.some(c => c.id === r.id);
+
+              return (
+                <div
+                  key={r.id}
+                  id={`node-${r.id.replace(/\//g, '-')}`}
+                  onMouseEnter={() => setHoveredRegime(r)}
+                  onMouseLeave={() => setHoveredRegime(null)}
+                  className={`rounded-full border font-mono font-semibold transition-all cursor-pointer ${size.padding} ${size.font} ${size.scale} ${
+                    isHovered
+                      ? 'bg-[var(--accent-cyan)] text-black border-[var(--accent-cyan)] shadow-[0_0_12px_rgba(0,240,255,0.45)] z-20'
+                      : isConnected
+                      ? 'bg-[rgba(0,240,255,0.06)] border-[rgba(0,240,255,0.4)] text-[var(--accent-cyan)] shadow-[0_0_8px_rgba(0,240,255,0.05)] z-20'
+                      : 'bg-[#121420] border-[rgba(255,255,255,0.04)] text-[var(--text-secondary)] hover:border-[rgba(255,255,255,0.15)]'
+                  }`}
+                  style={{ whiteSpace: 'nowrap', borderRadius: '9999px', cursor: 'pointer', transition: 'all var(--transition-fast)' }}
+                >
+                  {name}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Column 3 & 4: Global Empires */}
+        <div 
+          className="col-span-2 overflow-y-auto max-h-full space-y-2.5 p-2 bg-[rgba(255,255,255,0.01)] rounded border border-[rgba(255,255,255,0.02)] scroll-fade-y" 
+          style={{ gridColumn: 'span 2', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: '8px', padding: '8px' }}
+        >
+          <span className="text-[9px] text-purple-400 font-mono font-bold tracking-wider block" style={{ fontSize: '9px' }}>
+            GLOBAL REGIONS
+          </span>
+          <div className="flex flex-wrap gap-2 align-content-start" style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', alignContent: 'flex-start' }}>
+            {globalRegimes.map((r) => {
+              const name = r.id.split('/').pop()?.replace('-', ' ') || '';
+              const size = getNodeSizeStyle(r.metadata?.agentCount);
+              const isHovered = hoveredRegime?.id === r.id;
+              const isConnected = connections.some(c => c.id === r.id);
+
+              return (
+                <div
+                  key={r.id}
+                  id={`node-${r.id.replace(/\//g, '-')}`}
+                  onMouseEnter={() => setHoveredRegime(r)}
+                  onMouseLeave={() => setHoveredRegime(null)}
+                  className={`rounded-full border font-mono font-semibold transition-all cursor-pointer ${size.padding} ${size.font} ${size.scale} ${
+                    isHovered
+                      ? 'bg-[var(--accent-cyan)] text-black border-[var(--accent-cyan)] shadow-[0_0_12px_rgba(0,240,255,0.45)] z-20'
+                      : isConnected
+                      ? 'bg-[rgba(0,240,255,0.06)] border-[rgba(0,240,255,0.4)] text-[var(--accent-cyan)] shadow-[0_0_8px_rgba(0,240,255,0.05)] z-20'
+                      : 'bg-[#121420] border-[rgba(255,255,255,0.04)] text-[var(--text-secondary)] hover:border-[rgba(255,255,255,0.15)]'
+                  }`}
+                  style={{ whiteSpace: 'nowrap', borderRadius: '9999px', cursor: 'pointer', transition: 'all var(--transition-fast)' }}
+                >
+                  {name}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Column 5: Right sidebar detailed hovered node tooltips */}
+        <div 
+          className="col-span-1 glass-panel p-4 bg-[rgba(10,11,16,0.5)] border-[rgba(255,255,255,0.05)] flex flex-col justify-center h-full"
+          style={{ gridColumn: 'span 1', display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: '16px', borderRadius: '8px', zIndex: 20 }}
+        >
+          {hoveredRegime ? (
+            <div className="space-y-4 animate-fade-in" style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+              <div className="border-b border-[rgba(255,255,255,0.06)] pb-2" style={{ borderBottom: '1px solid rgba(255,255,255,0.06)', paddingBottom: '8px' }}>
+                <span className="text-[8px] text-[var(--text-muted)] font-mono uppercase tracking-wider block">HOVER INSPECTOR</span>
+                <h4 className="text-xs font-bold text-[var(--text-primary)] uppercase font-mono mt-0.5">
+                  {hoveredRegime.id.split('/').pop()?.replace('-', ' ')}
+                </h4>
+              </div>
+
+              <div className="space-y-2.5 text-[10px] text-[var(--text-secondary)] font-mono" style={{ display: 'flex', flexDirection: 'column', gap: '10px', fontSize: '10px' }}>
+                <div>
+                  <span className="text-[8px] text-[var(--text-muted)] block">ERA:</span>
+                  <span className="text-cyan-300 block leading-tight">{hoveredRegime.metadata?.era?.en || 'Ancient'}</span>
+                </div>
+                <div>
+                  <span className="text-[8px] text-[var(--text-muted)] block">PATTERN:</span>
+                  <span className="text-purple-300 block leading-tight">{hoveredRegime.metadata?.orchestrationPattern}</span>
+                </div>
+                <div>
+                  <span className="text-[8px] text-[var(--text-muted)] block">AGENT TEAMS:</span>
+                  <span className="text-amber-400 block font-bold">{hoveredRegime.metadata?.agentCount || 5} nodes</span>
+                </div>
+                <div>
+                  <span className="text-[8px] text-[var(--text-muted)] block">INFLUENCE TAGS:</span>
+                  <div className="flex flex-wrap gap-1 mt-1" style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '4px' }}>
+                    {(hoveredRegime.metadata?.tags || []).map((tag, idx) => (
+                      <span key={idx} className="text-[8px] bg-[rgba(255,255,255,0.04)] px-1.5 py-0.5 rounded border border-[rgba(255,255,255,0.06)]" style={{ fontSize: '8px', padding: '1px 4px' }}>
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="text-center text-[var(--text-muted)] text-[10px] space-y-2" style={{ textAlign: 'center', fontSize: '10px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <Network size={20} className="mx-auto text-[rgba(255,255,255,0.05)]" style={{ margin: '0 auto' }} />
+              <span>Hover a regime node to analyze shared tags connections timeline.</span>
+            </div>
+          )}
+        </div>
+
+      </div>
+
+    </div>
+  );
+};
+export default RelationshipNetwork;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -2,8 +2,13 @@
 
 export interface RegimeMetadata {
   id: string;
-  name?: string;
+  name?: string | { zh: string; en: string };
+  era?: { zh: string; en: string };
   epoch?: string;
+  region?: 'china' | 'global' | string;
+  system?: { zh: string; en: string };
+  description?: { zh: string; en: string };
+  agentCount?: number;
   orchestrationPattern: string;
   tags?: string[];
 }

--- a/frontend/src/types/regime.ts
+++ b/frontend/src/types/regime.ts
@@ -1,0 +1,14 @@
+// Type declarations for R2 Regime Visualization Browser
+
+export interface IdentityRole {
+  roleName: string;
+  agentId: string;
+  responsibility: string;
+  model: string;
+}
+
+export interface IdentityData {
+  id: string;
+  region: string;
+  raw: string | null;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,9 @@ function civagentApiPlugin() {
               if (!fs.existsSync(dir)) return;
               const files = fs.readdirSync(dir);
               for (const file of files) {
+                // Ignore templates or hidden directories/files starting with _ or .
+                if (file.startsWith('_') || file.startsWith('.')) continue;
+
                 const fullPath = path.join(dir, file);
                 if (fs.statSync(fullPath).isDirectory()) {
                   if (fs.existsSync(path.join(fullPath, 'metadata.json'))) {
@@ -88,9 +91,28 @@ function civagentApiPlugin() {
             if (parts.length >= 4) {
               const region = parts[1];
               const id = parts[2];
+
+              // Validation to prevent path traversal
+              const nameRegex = /^[a-zA-Z0-9_-]+$/;
+              if (!nameRegex.test(region) || !nameRegex.test(id)) {
+                res.statusCode = 400;
+                res.end(JSON.stringify({ error: 'Invalid region or regime ID' }));
+                return;
+              }
+
               const projectRoot = path.resolve(__dirname, '..');
-              const identityPath = path.join(projectRoot, 'regimes', region, id, 'IDENTITY.md');
+              const regimesDir = path.join(projectRoot, 'regimes');
+              const identityPath = path.join(regimesDir, region, id, 'IDENTITY.md');
               
+              const resolvedRegimesDir = path.resolve(regimesDir);
+              const resolvedIdentityPath = path.resolve(identityPath);
+
+              if (!resolvedIdentityPath.startsWith(resolvedRegimesDir + path.sep)) {
+                res.statusCode = 403;
+                res.end(JSON.stringify({ error: 'Access denied: path traversal detected' }));
+                return;
+              }
+
               if (fs.existsSync(identityPath)) {
                 try {
                   const raw = fs.readFileSync(identityPath, 'utf8');

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -82,6 +82,30 @@ function civagentApiPlugin() {
             return;
           }
 
+          // Endpoint: /api/regimes/:region/:id/identity
+          if (url.startsWith('/regimes/') && url.endsWith('/identity')) {
+            const parts = url.split('/').filter(Boolean);
+            if (parts.length >= 4) {
+              const region = parts[1];
+              const id = parts[2];
+              const projectRoot = path.resolve(__dirname, '..');
+              const identityPath = path.join(projectRoot, 'regimes', region, id, 'IDENTITY.md');
+              
+              if (fs.existsSync(identityPath)) {
+                try {
+                  const raw = fs.readFileSync(identityPath, 'utf8');
+                  res.end(JSON.stringify({ id, region, raw }));
+                } catch (err: any) {
+                  res.statusCode = 500;
+                  res.end(JSON.stringify({ error: err.message }));
+                }
+              } else {
+                res.end(JSON.stringify({ id, region, raw: null }));
+              }
+              return;
+            }
+          }
+
           // Endpoint: /api/tournaments
           if (url === '/tournaments' || url === '/tournaments/') {
             const tournamentsDir = path.join(rootDir, 'tournaments');


### PR DESCRIPTION
Adds the R2 Form ② Regime Visualization Browser frontend: Regimes tab, org chart, mode comparison, relationship network, regime API types, and Vite dev API support.

Review fixes included:
- Harden /api/regimes/:region/:id/identity against path traversal
- Exclude _template/hidden regime directories from the API listing
- Guard invalid regime ID split handling
- Stop OrgChart role-table parsing when leaving the table
- Support empty role states and EU multi-center coordinator detection

Verification:
- npm run build