### PR TITLE
feat: 显式声明 cn-cc-workflow 依赖（执行引擎）

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -21,6 +21,12 @@ and 37 global empires, creating a universal multi-regime governance platform.
 - Fork maintained by [@LeoLin990405](https://github.com/LeoLin990405) — a data professional & online part-time history undergraduate & AI programming enthusiast
 - Original concept and Tang Dynasty implementation: [@wanikua](https://github.com/wanikua)
 
+## Runtime Dependency / 运行时依赖
+
+CivAgent uses **[cn-cc-workflow](https://github.com/LeoLin990405/cn-cc-workflow)** (Apache-2.0) as its multi-agent **execution engine**: the `cn:*` civ backends (`cn:doubao`, `cn:glm`, …) are the `cc-*` launchers that project provides. CivAgent stays the orchestration / regime / dashboard layer on top; cn-cc-workflow runs the implementers. See `engine/cn-cc.mjs` (dependency check) and the contract at [cn-cc-workflow/docs/INTEGRATIONS.md](https://github.com/LeoLin990405/cn-cc-workflow/blob/main/docs/INTEGRATIONS.md).
+
+> Two clean repos (not merged): licenses differ (CivAgent MIT, cn-cc-workflow Apache-2.0). Install the engine: `git clone https://github.com/LeoLin990405/cn-cc-workflow && cd cn-cc-workflow && ./backends/install.sh`.
+
 ## Inspirations & Key References / 灵感来源 & 主要参考
 
 - **[@wanikua](https://github.com/wanikua)** — The original [AI 朝廷](https://github.com/wanikua/boluobobo-ai-court-tutorial) project that started it all

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
   <img src="https://img.shields.io/badge/License-MIT-yellowgreen?style=for-the-badge" />
 </p>
 
+<p align="center">
+  🔧 <b>执行引擎 / Execution engine</b>：<code>cn:*</code> 后端跑在 <a href="https://github.com/LeoLin990405/cn-cc-workflow">cn-cc-workflow</a> 上 — civagent 管编排，cn-cc 管执行（见 <a href="./CREDITS.md">CREDITS</a> / <code>engine/cn-cc.mjs</code>）
+</p>
+
 > **一种假说**：人类在五千年间反复实验的政治制度（中央集权、三权分立、民主议会、联邦自治、神权统治、双轨制衡），本质上是对**多实体协作问题**的历史解答。如果把每个 AI agent 类比为一个"臣子"、把问题求解过程类比为"治理过程"，那么 57 种历史政体就是 57 套**可复用的多智能体编排模式**——各自在真实历史中经受过数十年乃至千年的压力测试。
 >
 > *"The present is history's laboratory; the past, its ruined library."*

--- a/engine/cn-cc.mjs
+++ b/engine/cn-cc.mjs
@@ -1,0 +1,49 @@
+// cn-cc.mjs — CivAgent's explicit dependency on cn-cc-workflow.
+//
+// CivAgent's `cn:*` civ backends (cn:doubao, cn:glm, ...) are NOT implemented
+// here — they are the `cc-*` launchers provided by the cn-cc-workflow project,
+// which CivAgent uses as its multi-agent EXECUTION ENGINE. CivAgent stays the
+// orchestration / regime / dashboard layer on top.
+//
+//   cn-cc-workflow: https://github.com/LeoLin990405/cn-cc-workflow
+//   contract:       <that repo>/docs/INTEGRATIONS.md
+//
+// This module makes the dependency explicit and checkable (instead of failing
+// late inside a spawned cc-* process).
+import { execSync } from "node:child_process";
+import { BACKEND_COMMANDS } from "./v5/backends.mjs";
+
+export const CN_CC_REPO = "https://github.com/LeoLin990405/cn-cc-workflow";
+export const CN_CC_INSTALL =
+  `git clone ${CN_CC_REPO} && cd cn-cc-workflow && ./backends/install.sh  # keys in ~/.config/cc-model-secrets.env`;
+
+// Every backend id whose command is a cn-cc `cc-*` launcher.
+export const CN_CC_BACKENDS = Object.fromEntries(
+  Object.entries(BACKEND_COMMANDS).filter(([, cmd]) => cmd.startsWith("cc-")),
+);
+
+function onPath(cmd) {
+  try {
+    execSync(`command -v ${cmd}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Verify the cn-cc-workflow launchers this CivAgent install relies on are present.
+// Returns { ok, present[], missing[], repo, install } — never throws.
+export function checkCnCc() {
+  const present = [];
+  const missing = [];
+  for (const [id, cmd] of Object.entries(CN_CC_BACKENDS)) {
+    (onPath(cmd) ? present : missing).push({ id, cmd });
+  }
+  return {
+    ok: missing.length === 0,
+    present,
+    missing,
+    repo: CN_CC_REPO,
+    install: CN_CC_INSTALL,
+  };
+}

--- a/test/cn-cc.test.mjs
+++ b/test/cn-cc.test.mjs
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CN_CC_BACKENDS, checkCnCc, CN_CC_REPO } from "../engine/cn-cc.mjs";
+
+test("CN_CC_BACKENDS maps cn:* civ backends to cn-cc cc-* launchers", () => {
+  assert.ok(Object.keys(CN_CC_BACKENDS).length >= 6, "expect the cn:* fleet");
+  assert.equal(CN_CC_BACKENDS["cn:doubao"], "cc-doubao");
+  assert.equal(CN_CC_BACKENDS["cn:glm"], "cc-glm");
+  // every value is a cc-* launcher
+  for (const cmd of Object.values(CN_CC_BACKENDS)) assert.match(cmd, /^cc-/);
+  // claude / codex / opencode are NOT cn-cc-provided backends
+  assert.ok(!("claude" in CN_CC_BACKENDS));
+  assert.ok(!("codex" in CN_CC_BACKENDS));
+});
+
+test("checkCnCc returns a structured, non-throwing result", () => {
+  const r = checkCnCc();
+  assert.equal(typeof r.ok, "boolean");
+  assert.ok(Array.isArray(r.present) && Array.isArray(r.missing));
+  assert.equal(
+    r.present.length + r.missing.length,
+    Object.keys(CN_CC_BACKENDS).length,
+  );
+  assert.equal(r.repo, CN_CC_REPO);
+  assert.ok(typeof r.install === "string" && r.install.includes("install.sh"));
+});


### PR DESCRIPTION
civagent 的 `cn:*` 后端就是 cn-cc-workflow 的 `cc-*` 启动器——把隐式依赖显式化（**两仓干净依赖，非合并**：license MIT≠Apache-2.0）。

## 改动（纯新增，不碰正在重构的 backends.mjs）
- `engine/cn-cc.mjs`：`CN_CC_BACKENDS`(cn:*→cc-*) + `checkCnCc()`(校验 cc-* 在 PATH，缺则指向 cn-cc 安装) + repo/契约链接
- `test/cn-cc.test.mjs`：2 例（全量 **77→79 全绿**）
- `CREDITS.md`：Runtime Dependency 段

## 后续（不在本 PR）
深度接入（civagent dispatch 路由进 `fanout` 拿 cache/barrier/loop）等 `refactor/backend-arg-contract` 合并后单独做。契约见 [cn-cc-workflow/docs/INTEGRATIONS.md](https://github.com/LeoLin990405/cn-cc-workflow/blob/main/docs/INTEGRATIONS.md)。